### PR TITLE
Set prerelease:false when creating a new release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
         run: make test
 
       - name: Integration Tests
-        run: bb --main release-on-push-action.core --dry-run
+        run: make integration-test
         env:
           BABASHKA_CLASSPATH: src
           INPUT_BUMP_VERSION_SCHEME: minor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/r/borkdude/babashka
-FROM borkdude/babashka:0.0.78
+FROM borkdude/babashka:0.0.81
 
 WORKDIR /var/src/release-on-push-action
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: test
+.PHONY: test integration-test
 
 repl:
 	~/Downloads/bb --verbose --classpath "src" --nrepl-server
 
 test:
 	bb --classpath "src:test" run_tests.clj
+
+integration-test:
+	bb --verbose --main release-on-push-action.core --dry-run

--- a/local-test.env
+++ b/local-test.env
@@ -1,0 +1,6 @@
+# Setups a local environment to simulate a Github Action run
+export GITHUB_TOKEN=1234
+export GITHUB_REPOSITORY=rymndhng/release-on-push-action
+export GITHUB_SHA=1234
+export BABASHKA_CLASSPATH=src
+export INPUT_BUMP_VERSION_SCHEME=minor

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -102,7 +102,7 @@
      :name             next-version
      :body             (format "Version %s\n\n### Commits\n\n%s" next-version summary-since-last-release)
      :draft            false
-     :prerelease       true}))
+     :prerelease       false}))
 
 (defn create-new-release! [context new-release-data]
   ;; Use a file because the release data may be too large for an inline curl arg

--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -4,20 +4,6 @@
             [cheshire.core :as json]))
 
 ;; -- Generic HTTP Helpers  ----------------------------------------------------
-(defn resp->map
-  "See https://gist.github.com/dainiusjocas/d2a5ca60ae25cd260f37b7c125a0b2e6"
-  [resp]
-  (let [lines   (str/split resp #"\r\n")
-        status  (Integer/parseInt (second (str/split (first lines) #" ")))
-        headers (reduce (fn [acc header-line]
-                          (let [[k v] (str/split header-line #":" 2)]
-                            (assoc acc (str/lower-case k) (str/trim v))))
-                        {}
-                        (remove str/blank? (drop-last (rest lines))))]
-    {:body    (last lines)
-     :status  status
-     :headers headers}))
-
 (defn link-header->map
   "Converts link header into a map of rel -> link. This implementation is not standards compliant.
 
@@ -35,7 +21,6 @@
 
 (defn parse-response [resp]
   (-> resp
-      (resp->map)
       (with-links)
       (update :body json/parse-string true)))
 
@@ -43,8 +28,7 @@
 (defn follow-link [context link]
   (parse-response
    (curl/get link
-             {:headers {"Authorization" (str "token " (:token context))}
-              :raw-args ["-i"]})))
+             {:headers {"Authorization" (str "token " (:token context))}})))
 
 (defn paginate
   "Paginate a resopnse with a context object"
@@ -62,7 +46,6 @@
   (parse-response
    (curl/get "https://api.github.com/search/issues"
              {:headers      {"Authorization" (str "token " (:token context))}
-              :raw-args     ["-i"]
               :query-params {"q" (format "repo:%s type:pr is:closed is:merged SHA:%s" (:repo context) (:sha context))}})))
 
 ;; -- Github Releases API  -----------------------------------------------------
@@ -72,8 +55,7 @@
   (parse-response
    (curl/get
     (format "https://api.github.com/repos/%s/releases/latest" (:repo context))
-    {:headers {"Authorization" (str "token " (:token context))}
-     :raw-args ["-i"]})))
+    {:headers {"Authorization" (str "token " (:token context))}})))
 
 ;; -- Github Commit API  -------------------------------------------------------
 (defn fetch-commit
@@ -81,8 +63,7 @@
   [context]
   (parse-response
    (curl/get (format "https://api.github.com/repos/%s/commits/%s" (:repo context) (:sha context))
-             {:headers {"Authorization" (str "token " (:token context))}
-              :raw-args ["-i"]})))
+             {:headers {"Authorization" (str "token " (:token context))}})))
 
 (defn list-commits
   "Gets all commits between two commit shas.
@@ -91,8 +72,7 @@
   [context]
   (parse-response
    (curl/get (format "https://api.github.com/repos/%s/commits" (:repo context))
-             {:headers {"Authorization" (str "token " (:token context))}
-              :raw-args ["-i"]
+             {:headers      {"Authorization" (str "token " (:token context))}
               :query-params {"sha" (:sha context)}})))
 
 (defn list-commits-to-base


### PR DESCRIPTION
This ensures that the next `release` can find the correct tag to start from.

Fixes #29.