### PR TITLE
Fix NullPointerException on Release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,3 +42,14 @@ jobs:
         env:
           INPUT_BUMP_VERSION_SCHEME: minor
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Disable me if needed to debug curl/post action
+  # create-prerelease:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: rymndhng/release-on-push-action@debug-npe
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         CREATE_DRAFT: true
+  #       with:
+  #         bump_version_scheme: patch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/r/borkdude/babashka
-FROM borkdude/babashka:0.0.81
+FROM borkdude/babashka:0.0.82-SNAPSHOT
 
 WORKDIR /var/src/release-on-push-action
 


### PR DESCRIPTION
There appears to be an error on babashka 0.0.81 that causes NullPointerExceptions on `curl/post`.

From testing, the issue seems to come from usage of `:body file` where `file` is a `java.io.File`. The short-term workaround is to use 0.0.82-SNAPSHOT, and a bit more time debugging the underlying issue.