### PR TITLE
Add output parameter for version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Output Parameters
-        run: echo "Got version ${{ steps.integration-tests.outputs.tag_name }}"
+        run: |
+          echo "Got tag version ${{ steps.integration-tests.outputs.tag_name }}"
+          echo "Got version ${{ steps.integration-tests.outputs.version }}"
 
       - name: Container Builds
         run: docker build . -t rymndhng/release-on-push-action

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ track what the last release version is. See [Release#get-the-latest-release](htt
 
 ### How can I get the generated tag or version?
 
-On a successful release, this action creates an output parameters `tag_name` and `name`. 
+On a successful release, this action creates an output parameters `tag_name` and `version`. 
 
 Example of how to consume this:
 
@@ -102,11 +102,10 @@ jobs:
         with:
           bump_version_scheme: minor
           
-      - name: Check tag Output Parameter
-        run: echo "Got tag name ${{ steps.release.outputs.tag_name }}"
-
-      - name: Check version Output Parameter
-        run: echo "Got version ${{ steps.release.outputs.name }}"
+      - name: Check Output Parameters
+        run: |
+          echo "Got tag name ${{ steps.release.outputs.tag_name }}"
+          echo "Got release version ${{ steps.release.outputs.version }}"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Currently, no.
 In order to reliably generate monotonic versions, we use Github Releases to
 track what the last release version is. See [Release#get-the-latest-release](https://developer.github.com/v3/repos/releases/#get-the-latest-release).
 
-### How can I get the generated tag version?
+### How can I get the generated tag or version?
 
-On a successful release, this action creates create an output parameter `tag_name`. 
+On a successful release, this action creates create an output parameters `tag_name` and `output`. 
 
 Example of how to consume this:
 
@@ -98,12 +98,15 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - id: release
-        uses: rymndhng/release-on-push-action@v0.14.0
+        uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: minor
           
-      - name: Check Output Parameters
+      - name: Check tag Output Parameter
         run: echo "Got version ${{ steps.release.outputs.tag_name }}"
+
+      - name: Check version Output Parameter
+        run: echo "Got version ${{ steps.release.outputs.name }}"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ jobs:
           bump_version_scheme: minor
           
       - name: Check tag Output Parameter
-        run: echo "Got version ${{ steps.release.outputs.tag_name }}"
+        run: echo "Got tag name ${{ steps.release.outputs.tag_name }}"
 
       - name: Check version Output Parameter
         run: echo "Got version ${{ steps.release.outputs.name }}"

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ track what the last release version is. See [Release#get-the-latest-release](htt
 
 ### How can I get the generated tag or version?
 
-On a successful release, this action creates create an output parameters `tag_name` and `output`. 
+On a successful release, this action creates an output parameters `tag_name` and `name`. 
 
 Example of how to consume this:
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ inputs:
     required: true
 outputs:
   tag_name:
-    description: 'Tag of released version.'
+    description: 'Tag of released version'
   version:
-    description: "Version or release"
+    description: 'Version of release'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
 outputs:
   tag_name:
     description: 'Tag of released version.'
+  version:
+    description: "Version or release"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -119,7 +119,8 @@
   See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
   "
   [release-data]
-  (printf "::set-output name=tag_name::%s\n" (:tag_name release-data)))
+  (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
+  (printf "::set-output name=name::%s\n" (:name release-data)))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -99,7 +99,7 @@
 
     {:tag_name         (str "v" next-version)
      :target_commitish (:sha context)
-     :name             next-version
+     :version          next-version
      :body             (format "Version %s\n\n### Commits\n\n%s" next-version summary-since-last-release)
      :draft            false
      :prerelease       false}))
@@ -120,7 +120,7 @@
   "
   [release-data]
   (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
-  (printf "::set-output name=name::%s\n" (:name release-data)))
+  (printf "::set-output name=version::%s\n" (:version release-data)))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -99,7 +99,7 @@
 
     {:tag_name         (str "v" next-version)
      :target_commitish (:sha context)
-     :version          next-version
+     :name             next-version
      :body             (format "Version %s\n\n### Commits\n\n%s" next-version summary-since-last-release)
      :draft            false
      :prerelease       false}))
@@ -120,7 +120,7 @@
   "
   [release-data]
   (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
-  (printf "::set-output name=version::%s\n" (:version release-data)))
+  (printf "::set-output name=version::%s\n" (:name release-data)))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")


### PR DESCRIPTION
For ability to create packages, need to have version number like 1.0.0 instead of tag name like v1.0.0
This PR add output parameter name which contains info about version number for such uses