### PR TITLE
Add customization `tag_prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ jobs:
         uses: rymndhng/release-on-push-action@master
         with:
           bump_version_scheme: minor
+          tag_prefix: v
           
       - name: Check Output Parameters
         run: |
@@ -132,6 +133,27 @@ jobs:
           release_body: "When set, adds extra text to body!"
 ```
 
+### Can I change the prefix `v` from the Git Tags?
+
+Yes, you can customize this by changing the `tag_prefix`. Here's an example of
+removing the prefix by using an empty string.
+ 
+``` yaml
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          tag_prefix: ""
+```
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   release_body:
     description: "Additional text to insert into the release's body."
     required: false
+  tag_prefix:
+    description: "Prefix to append to git tags. Defaults to `v`. To unset this, set version_prefix to an empty string."
+    required: false
 outputs:
   tag_name:
     description: 'Tag of released version'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -33,6 +33,7 @@
    :repo                (getenv-or-throw "GITHUB_REPOSITORY")
    :sha                 (getenv-or-throw "GITHUB_SHA")
    :input/release-body  (System/getenv "INPUT_RELEASE_BODY")
+   :input/tag-prefix    (get (System/getenv) "INPUT_TAG_PREFIX" "v") ;allows passing in an empty string as a valid value
    :bump-version-scheme (assert-valid-bump-version-scheme
                          (try
                            (getenv-or-throw "INPUT_BUMP_VERSION_SCHEME")
@@ -60,10 +61,10 @@
       (contains? labels "release:patch") :patch
       :else (keyword (:bump-version-scheme context)))))
 
-(defn get-tagged-version [latest-release]
+(defn get-tagged-version [prefix latest-release]
   (let [tag (get latest-release :tag_name "0.0.0")]
-    (if (.startsWith tag "v")
-      (subs tag 1)
+    (if (.startsWith tag prefix)
+      (subs tag (count prefix))
       tag)))
 
 (defn safe-inc [n]
@@ -90,7 +91,7 @@
 
 (defn generate-new-release-data [context related-data]
   (let [bump-version-scheme (bump-version-scheme context related-data)
-        current-version     (get-tagged-version (:latest-release related-data))
+        current-version     (get-tagged-version (:input/tag-prefix context) (:latest-release related-data))
         next-version        (semver-bump current-version bump-version-scheme)
 
         ;; assumption: target_commitish is always a sha and not a reference
@@ -98,7 +99,7 @@
                                         (map github/commit-summary)
                                         (str/join "\n"))]
 
-    {:tag_name         (str "v" next-version)
+    {:tag_name         (str (:input/tag-prefix context) next-version)
      :target_commitish (:sha context)
      :name             next-version
      :body             (with-out-str

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -3,11 +3,19 @@
             [release-on-push-action.core :as sut]))
 
 (deftest get-tagged-version
-  (are [expected tag-name] (= expected (sut/get-tagged-version {:tag_name tag-name}))
-    "0.0.0" "v0.0.0"
-    "0.0.0" "0.0.0"
-    "1.0.0" "v1.0.0"
-    "1.0.0" "1.0.0"))
+  (testing "with default prefix"
+    (are [expected tag-name] (= expected (sut/get-tagged-version "v" {:tag_name tag-name}))
+      "0.0.0" "v0.0.0"
+      "0.0.0" "0.0.0"
+      "1.0.0" "v1.0.0"
+      "1.0.0" "1.0.0"))
+
+  (testing "with no prefix"
+    (are [expected tag-name] (= expected (sut/get-tagged-version "" {:tag_name tag-name}))
+      "v0.0.0" "v0.0.0"
+      "0.0.0" "0.0.0"
+      "v1.0.0" "v1.0.0"
+      "1.0.0" "1.0.0")))
 
 (deftest semver-bump
   (testing "patch bump"


### PR DESCRIPTION
This allows users to change the `v`, or strip the `v` from tags. See README.md for updated instructions.

Fixes #42

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests (tested in https://github.com/release-on-push-action-test/bug-test)
- [x] Have set labels for release level