### PR TITLE
Improve default value handling of tag_prefix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           BABASHKA_CLASSPATH: src
           INPUT_BUMP_VERSION_SCHEME: minor
+          INPUT_TAG_PREFIX: v
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Output Parameters

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,13 +46,14 @@ jobs:
         run: docker build . -t rymndhng/release-on-push-action
 
       - name: Container Test
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_TAG_PREFIX -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
         env:
           INPUT_BUMP_VERSION_SCHEME: minor
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG_PREFIX: v
 
       - name: Container Test with Release Notes
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_TAG_PREFIX -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
         env:
           INPUT_RELEASE_BODY: |
             This is a test
@@ -60,6 +61,19 @@ jobs:
 
             Does it work?
           INPUT_BUMP_VERSION_SCHEME: minor
+          INPUT_TAG_PREFIX: v
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Container Test with no prefix
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_TAG_PREFIX -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
+        env:
+          INPUT_RELEASE_BODY: |
+            This is a test
+            with multi-line input
+
+            Does it work?
+          INPUT_BUMP_VERSION_SCHEME: minor
+          INPUT_TAG_PREFIX:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Disable me if needed to debug curl/post action

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,6 +64,18 @@ jobs:
           INPUT_TAG_PREFIX: v
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Container Test with no prefix
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_TAG_PREFIX -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
+        env:
+          INPUT_RELEASE_BODY: |
+            This is a test
+            with multi-line input
+
+            Does it work?
+          INPUT_BUMP_VERSION_SCHEME: minor
+          INPUT_TAG_PREFIX:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Disable me if needed to debug curl/post action
   # create-prerelease:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,18 +64,6 @@ jobs:
           INPUT_TAG_PREFIX: v
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Container Test with no prefix
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_TAG_PREFIX -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
-        env:
-          INPUT_RELEASE_BODY: |
-            This is a test
-            with multi-line input
-
-            Does it work?
-          INPUT_BUMP_VERSION_SCHEME: minor
-          INPUT_TAG_PREFIX:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Disable me if needed to debug curl/post action
   # create-prerelease:
   #   runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,9 @@ inputs:
     description: "Additional text to insert into the release's body."
     required: false
   tag_prefix:
-    description: "Prefix to append to git tags. Defaults to `v`. To unset this, set version_prefix to an empty string."
+    description: "Prefix to append to git tags. To unset this, set version_prefix to an empty string."
     required: false
+    default: 'v'
 outputs:
   tag_name:
     description: 'Tag of released version'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -33,7 +33,7 @@
    :repo                (getenv-or-throw "GITHUB_REPOSITORY")
    :sha                 (getenv-or-throw "GITHUB_SHA")
    :input/release-body  (System/getenv "INPUT_RELEASE_BODY")
-   :input/tag-prefix    (get (System/getenv) "INPUT_TAG_PREFIX" "v") ;allows passing in an empty string as a valid value
+   :input/tag-prefix    (System/getenv "INPUT_TAG_PREFIX") ;defaults to "v", see default in action.yml
    :bump-version-scheme (assert-valid-bump-version-scheme
                          (try
                            (getenv-or-throw "INPUT_BUMP_VERSION_SCHEME")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -61,11 +61,10 @@
       (contains? labels "release:patch") :patch
       :else (keyword (:bump-version-scheme context)))))
 
-(defn get-tagged-version [prefix latest-release]
-  (let [tag (get latest-release :tag_name "0.0.0")]
-    (if (.startsWith tag prefix)
-      (subs tag (count prefix))
-      tag)))
+(defn get-tagged-version [latest-release]
+  (let [tag      (get latest-release :tag_name "0.0.0")
+        [prefix] (str/split tag #"\d+\.\d+\.\d+")] ;this strips any leading characters before the semver string
+    (subs tag (count prefix))))
 
 (defn safe-inc [n]
   (inc (or n 0)))
@@ -91,7 +90,7 @@
 
 (defn generate-new-release-data [context related-data]
   (let [bump-version-scheme (bump-version-scheme context related-data)
-        current-version     (get-tagged-version (:input/tag-prefix context) (:latest-release related-data))
+        current-version     (get-tagged-version (:latest-release related-data))
         next-version        (semver-bump current-version bump-version-scheme)
 
         ;; assumption: target_commitish is always a sha and not a reference

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -3,19 +3,14 @@
             [release-on-push-action.core :as sut]))
 
 (deftest get-tagged-version
-  (testing "with default prefix"
-    (are [expected tag-name] (= expected (sut/get-tagged-version "v" {:tag_name tag-name}))
-      "0.0.0" "v0.0.0"
-      "0.0.0" "0.0.0"
-      "1.0.0" "v1.0.0"
-      "1.0.0" "1.0.0"))
-
-  (testing "with no prefix"
-    (are [expected tag-name] (= expected (sut/get-tagged-version "" {:tag_name tag-name}))
-      "v0.0.0" "v0.0.0"
-      "0.0.0" "0.0.0"
-      "v1.0.0" "v1.0.0"
-      "1.0.0" "1.0.0")))
+  (are [expected tag-name] (= expected (sut/get-tagged-version {:tag_name tag-name}))
+    "0.0.0" "v0.0.0"
+    "0.0.0" "0.0.0"
+    "1.0.0" "v1.0.0"
+    "1.0.0" "1.0.0"
+    "1.0.0" "whatever1.0.0"
+    "1.0.0" "foo1-1.0.0"
+    "1.0.0" "111-1.0.0"))
 
 (deftest semver-bump
   (testing "patch bump"


### PR DESCRIPTION
In #44 , the new environment variable is always set which confuses the context-from-env. To fix this, we need to set the default value in `action.yml`.

This change also does a better job of guessing the tag prefix so that migration is easier for folks adopting the prefix.

# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level