### PR TITLE
Fallback to 0.0.0 when repository has no releases

### DIFF
--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -61,8 +61,9 @@
       {:headers {"Authorization" (str "token " (:token context))}}))
     (catch clojure.lang.ExceptionInfo ex
       (cond
-        ;; No previous release created
-        (= 404 (:status (ex-data ex))) nil
+        ;; No previous release created, return nil
+        (= 404 (:status (ex-data ex)))
+        (println "No release found for project.")
 
         :else (throw ex)))))
 


### PR DESCRIPTION
When a repository has no releases, the action should:
- assume the version is "0.0.0"
- summarize up to the most 500 recent commits

Currently, the action will throw an Exception of Status: 404.

Fixes #41

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level