### PR TITLE
Add version prefix to release name

### DIFF
--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -105,7 +105,7 @@
                                         (str/join "\n"))]
     {:tag_name         (str (:input/tag-prefix context) next-version)
      :target_commitish (:sha context)
-     :name             next-version
+     :name             (str (:input/tag-prefix context) next-version)
      :body             (with-out-str
                          (printf "Version %s\n\n" next-version)
                          (when-let [body (:input/release-body context)]


### PR DESCRIPTION
Append the tag prefix to the release title in addition to the tag name so that multi-site releases have different release titles

We are utilizing this Github action for multi-site releases

For each site, we append the tenant prefix to the tag_prefix: `{tenant}-v`

It would be preferable to append the optional tag_prefix to the Release title if it's passed

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests

```
bb --verbose --main release-on-push-action.core --dry-run
Starting process...
Received context {:token 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, :repo rymndhng/release-on-push-action, :sha a4ef2f44e868bb017df28c8532b80a4579e632e8, :input/release-body nil, :input/tag-prefix nil, :bump-version-scheme minor, :dry-run true}
Fetching related data...
Generating release...
Dry Run. Not performing release
 {
  "tag_name" : "0.19.0",
  "target_commitish" : "a4ef2f44e868bb017df28c8532b80a4579e632e8",
  "name" : "0.19.0",
  "body" : "Version 0.19.0\n\n### Commits\n\n- [a4ef2f44] Update core.clj to add tag prefix to title\n",
  "draft" : false,
  "prerelease" : false
}
Release Body
Version 0.19.0

### Commits

- [a4ef2f44] Update core.clj to add tag prefix to title

::set-output name=tag_name::0.19.0
::set-output name=version::0.19.0
```

- [x] Have set labels for release level