### PR TITLE
Add body to output parameters 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           echo "Got tag version ${{ steps.integration-tests.outputs.tag_name }}"
           echo "Got version ${{ steps.integration-tests.outputs.version }}"
+          echo "Got body ${{ steps.integration-tests.outputs.body }}"
 
       - name: Container Builds
         run: docker build . -t rymndhng/release-on-push-action

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,8 @@ outputs:
     description: 'Tag of released version'
   version:
     description: 'Version of release'
+  body:
+    description: 'Github Release Body in Text'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -132,7 +132,7 @@
   [release-data]
   (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
   (printf "::set-output name=version::%s\n" (:name release-data))
-  (printf "::set-output name=body::%s\n" (:body release-data)))
+  (printf "::set-output name=body::%s\n" (clojure.string/replace (:body release-data) #"\n" "%0A")))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -132,6 +132,7 @@
   [release-data]
   (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
   (printf "::set-output name=version::%s\n" (:name release-data)))
+  (printf "::set-output name=body::%s\n" (:body release-data)))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -124,15 +124,26 @@
                {:body    file
                 :headers {"Authorization" (str "token " (:token context))}})))
 
+(defn set-output-escape
+  "Escapes text for the set-output command in Github Actions.
+
+  See https://github.community/t/set-output-truncates-multiline-strings/16852
+  "
+  [text]
+  (-> text
+      (clojure.string/replace #"%" "%25")
+      (clojure.string/replace #"\n" "%0A")
+      (clojure.string/replace #"\r" "%0D")))
+
 (defn set-output-parameters!
   "Sets output parameters for additional tasks to consume.
 
   See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
   "
   [release-data]
-  (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
-  (printf "::set-output name=version::%s\n" (:name release-data))
-  (printf "::set-output name=body::%s\n" (clojure.string/replace (:body release-data) #"\n" "%0A")))
+  (printf "::set-output name=tag_name::%s\n" (set-output-escape (:tag_name release-data)))
+  (printf "::set-output name=version::%s\n" (set-output-escape (:name release-data)))
+  (printf "::set-output name=body::%s\n" (set-output-escape (:body release-data))))
 
 (defn -main [& args]
   (let [_            (println "Starting process...")

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -131,7 +131,7 @@
   "
   [release-data]
   (printf "::set-output name=tag_name::%s\n" (:tag_name release-data))
-  (printf "::set-output name=version::%s\n" (:name release-data)))
+  (printf "::set-output name=version::%s\n" (:name release-data))
   (printf "::set-output name=body::%s\n" (:body release-data)))
 
 (defn -main [& args]

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -12,6 +12,13 @@
     "1.0.0" "foo1-1.0.0"
     "1.0.0" "111-1.0.0"))
 
+(deftest set-output-escape
+  (are [expected input] (= expected (sut/set-output-escape input))
+    "hello world"     "hello world"
+    "hello%2520world" "hello%20world"
+    "hello%0Aworld"   "hello\nworld"
+    "hello%0Dworld"   "hello\rworld"))
+
 (deftest semver-bump
   (testing "patch bump"
     (are [expected input] (= expected (sut/semver-bump input :patch))


### PR DESCRIPTION
This is based on #47 with some additional improvements:

- updating outputs check in test
- escaping all calls to `set-output`
- updating `actions.yml`

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level