### PR TITLE
fix: reduce max number of commits to 50

### DIFF
--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -91,7 +91,7 @@
 ;; Note: at 500, I suspect this list will be unproductive to view
 (def max-commits-to-summarize
   "This is the maximum number of commits to summarize."
-  500)
+  50)
 
 (defn generate-new-release-data [context related-data]
   (let [bump-version-scheme (bump-version-scheme context related-data)


### PR DESCRIPTION
Minor change

To avoid overflowing the body capacity, we reduce the max number of commits.

When I run this command on a very active 6 months old projects, the first release generates a massive body. The action fails with 

>----- Error --------------------------------------------------------------------
Type:     clojure.lang.ExceptionInfo
Message:  babashka.curl: status 422
Location: /var/src/release-on-push-action/src/release_on_push_action/core.clj:123:5

----- Context ------------------------------------------------------------------
119:   ;; Use a file because the release data may be too large for an inline curl arg
120:   (let [file (java.io.File/createTempFile "release" ".json")]
121:     (.deleteOnExit file)
122:     (json/encode-stream new-release-data (clojure.java.io/writer file))
123:     (curl/post (format "https://api.github.com/repos/%s/releases" (:repo context))
         ^--- babashka.curl: status 422
124:                {:body    file
125:                 :headers {"Authorization" (str "token " (:token context))}})))
126: 
127: (defn set-output-parameters!
128:   "Sets output parameters for additional tasks to consume.

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level