### PR TITLE
[internals] Upgrade babashka to 0.6.1

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install babashka
-        run: sudo ./bin/install_babashka.sh --version 0.3.5
+        run: sudo ./bin/install_babashka.sh --version 0.6.1
 
       - name: Unit Tests
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://hub.docker.com/r/babashka/babashka
-FROM babashka/babashka:0.3.5
+FROM babashka/babashka:0.6.1
 
 WORKDIR /var/src/release-on-push-action
 


### PR DESCRIPTION
The newest version does a better job of logging uncaught exceptions. See https://github.com/babashka/babashka/pull/854

# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level