### PR TITLE
Fix format of releases API using GITHUB_API_URL

### DIFF
--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -57,7 +57,7 @@
   (try
     (parse-response
      (curl/get
-      (format "%s/%s/releases/latest" (:github/api-url context) (:repo context))
+      (format "%s/repos/%s/releases/latest" (:github/api-url context) (:repo context))
       {:headers {"Authorization" (str "token " (:token context))}}))
     (catch clojure.lang.ExceptionInfo ex
       (cond


### PR DESCRIPTION
This was introduced accidentally in #58 .

# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level