### PR TITLE
Rewrite Integration Tests using clojure.test and project fixtures.

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {release-on-push-action.core-test/def-fixture clojure.core/def}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,32 +55,6 @@ jobs:
           INPUT_TAG_PREFIX: v
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Container Test with Release Notes
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
-        env:
-          INPUT_RELEASE_BODY: |
-            This is a test
-            with multi-line input
-
-            Does it work?
-          INPUT_BUMP_VERSION_SCHEME: minor
-          INPUT_MAX_COMMITS: 5
-          INPUT_TAG_PREFIX: v
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Container Test with no prefix
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN -e INPUT_RELEASE_BODY rymndhng/release-on-push-action --dry-run
-        env:
-          INPUT_RELEASE_BODY: |
-            This is a test
-            with multi-line input
-
-            Does it work?
-          INPUT_BUMP_VERSION_SCHEME: minor
-          INPUT_TAG_PREFIX:
-          INPUT_MAX_COMMITS: 5
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   # Disable me if needed to debug curl/post action
   # create-prerelease:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,9 +28,8 @@ jobs:
       - name: Unit Tests
         run: make test
 
-      - name: Integration Tests
-        id: integration-tests
-        run: make integration-test
+      - name: Dry Run
+        run: make dryrun
         env:
           BABASHKA_CLASSPATH: src
           INPUT_BUMP_VERSION_SCHEME: minor

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Unit Tests
         run: make test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Dry Run
         run: make dryrun

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
 .env
-
-# Ignore state used for local testing
-last_commit
-last_release
-related_prs
-
+.clj-kondo/.cache
 .idea

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ repl:
 test:
 	bb --classpath "src:test" run_tests.clj
 
-integration-test:
+dryrun:
 	bb --verbose --main release-on-push-action.core --dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test integration-test
 
 repl:
-	bb --verbose --classpath "src" --nrepl-server
+	bb --verbose --classpath "src:test" --nrepl-server
 
 test:
 	bb --classpath "src:test" run_tests.clj

--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ To run tests:
 
 ``` sh
 make test
-
-# run integration tests
-source local-test.env
-make integration-tests
 ```
 
 

--- a/local-test.env
+++ b/local-test.env
@@ -1,8 +1,0 @@
-# Setups a local environment to simulate a Github Action run
-export GITHUB_API_URL=https://api.github.com
-export GITHUB_TOKEN=1234
-export GITHUB_REPOSITORY=rymndhng/release-on-push-action
-export GITHUB_SHA=1234
-export BABASHKA_CLASSPATH=src
-export INPUT_BUMP_VERSION_SCHEME=minor
-export INPUT_MAX_COMMITS=5

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -122,7 +122,7 @@
     (json/encode-stream new-release-data (clojure.java.io/writer file))
     (curl/post (format "%s/repos/%s/releases" (:github/api-url context) (:repo context))
                {:body    file
-                :headers {"Authorization" (str "token " (:token context))}})))
+                :headers (github/headers context)})))
 
 (defn set-output-escape
   "Escapes text for the set-output command in Github Actions.

--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -24,11 +24,13 @@
       (with-links)
       (update :body json/parse-string true)))
 
+(defn headers [context]
+  {"Authorization" (str "token " (:token context))})
+
 ;; -- Pagination helpers using token  ------------------------------------------
 (defn follow-link [context link]
   (parse-response
-   (curl/get link
-             {:headers {"Authorization" (str "token " (:token context))}})))
+   (curl/get link {:headers (headers context)})))
 
 (defn paginate
   "Paginate a resopnse with a context object"
@@ -45,7 +47,7 @@
   [context]
   (parse-response
    (curl/get (format "%s/search/issues" (:github/api-url context))
-             {:headers      {"Authorization" (str "token " (:token context))}
+             {:headers      (headers context)
               :query-params {"q" (format "repo:%s type:pr is:closed is:merged SHA:%s" (:repo context) (:sha context))}})))
 
 ;; -- Github Releases API  -----------------------------------------------------
@@ -58,7 +60,7 @@
     (parse-response
      (curl/get
       (format "%s/repos/%s/releases/latest" (:github/api-url context) (:repo context))
-      {:headers {"Authorization" (str "token " (:token context))}}))
+      {:headers (headers context)}))
     (catch clojure.lang.ExceptionInfo ex
       (cond
         ;; No previous release created, return nil
@@ -73,7 +75,7 @@
   [context]
   (parse-response
    (curl/get (format "%s/repos/%s/commits/%s" (:github/api-url context) (:repo context) (:sha context))
-             {:headers {"Authorization" (str "token " (:token context))}})))
+             {:headers (headers context)})))
 
 (defn list-commits
   "Gets all commits between two commit shas.
@@ -82,7 +84,7 @@
   [context]
   (parse-response
    (curl/get (format "%s/repos/%s/commits" (:github/api-url context) (:repo context))
-             {:headers      {"Authorization" (str "token " (:token context))}
+             {:headers      (headers context)
               :query-params {"sha" (:sha context)}})))
 
 (defn list-commits-to-base

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -1,5 +1,6 @@
 (ns release-on-push-action.core-test
   (:require [clojure.test :refer [deftest is are testing]]
+            [clojure.string :as str]
             [release-on-push-action.core :as sut]))
 
 (deftest get-tagged-version
@@ -40,3 +41,173 @@
       "1.0.0" "0.0.1"
       "1.0.0" "0.1.0"
       "2.0.0" "1.1.0")))
+
+(def base-ctx
+  {:token               (System/getenv "GITHUB_TOKEN") ;use Github Actions Token as test token
+   :github/api-url      "https://api.github.com"
+   :input/max-commits   5
+   :input/release-body  ""
+   :input/tag-prefix    ""
+   :bump-version-scheme "minor"
+   :dry-run             true})
+
+;; -- Integration Tests  -------------------------------------------------------
+(defmacro def-fixture
+  "Creates a Repository fixture whose value can be resolved to a pair of [ctx related-data]"
+  [name & ctx-args]
+  `(def ~name
+     (let [ctx# (merge base-ctx (hash-map ~@ctx-args))]
+       (delay [ctx# (sut/fetch-related-data ctx#)]))))
+
+;; This project has 11 commits and does not have any tags or releases.
+;; https://github.com/release-on-push-action/test-project-without-releases
+(def-fixture fixture-project-without-release
+  :repo "release-on-push-action/test-project-without-releases"
+  :sha  "946550e635d4bae50cb5cec434678b439b59c659")
+
+;; This project has 11 commits and has a release tag: v0.1.0 @ 536a71ab35383e0a2e8d8e3a1518eec6bc8b2cdc
+;; https://github.com/release-on-push-action/test-project-with-release/releases/latest
+(def-fixture fixture-project-with-release
+  :repo "release-on-push-action/test-project-with-release"
+  :sha "946550e635d4bae50cb5cec434678b439b59c659")
+
+(deftest ^:integration generate-new-release-data-from-new-project
+  (let [[ctx related-data] @fixture-project-without-release]
+    (testing "preconditions"
+      (is (= 0 (get-in related-data [:related-prs :total_count])))
+      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+      (is (nil? (:latest-release related-data)) "has no latest release"))
+
+    (testing "generate-new-release-data"
+      (let [release-data (sut/generate-new-release-data ctx related-data)]
+        (are [key expected] (= expected (get release-data key))
+          :tag_name "0.1.0"
+          :body     "Version 0.1.0
+
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+- [536a71ab] Commit 6
+")))
+
+    (testing "tag_name"
+      (testing ":bump-version-scheme"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "1.0.0"
+          "minor" "0.1.0"
+          "patch" "0.0.1"))
+      (testing "with prefix"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+                                                          :input/tag-prefix "v")
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "v1.0.0"
+          "minor" "v0.1.0"
+          "patch" "v0.0.1")))
+
+    (testing "body"
+      (testing ":input/release-body"
+        (is (= "Version 0.1.0
+
+Hello World
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+- [536a71ab] Commit 6
+"
+               (-> (assoc ctx :input/release-body "Hello World\n")
+                   (sut/generate-new-release-data related-data)
+                   (get :body)))))
+
+      (testing ":input/max-commits"
+        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :body)
+                                                      (str/split-lines)
+                                                      (last)))
+          1   "- [946550e6] Commit 10"
+          5   "- [536a71ab] Commit 6"
+          10  "- [8c0eef57] Commit 1"
+          11  "- [2db43d3a] Initial commit"
+          100 "- [2db43d3a] Initial commit"     ;larger number than what's available
+          )))))
+
+(deftest ^:integration generate-new-release-data-from-existing-release
+  (let [[ctx related-data] @fixture-project-with-release]
+    (testing "preconditions"
+      (is (= 0 (get-in related-data [:related-prs :total_count])))
+      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+      (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
+
+    (testing "generate-new-release-data"
+      (let [release-data (sut/generate-new-release-data ctx related-data)]
+        (are [key expected] (= expected (get release-data key))
+          :tag_name "0.2.0"
+
+          ;; note that commit 6 is not included here
+          :body "Version 0.2.0
+
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+")))
+
+    (testing "tag_name"
+      (testing ":bump-version-scheme"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "1.0.0"
+          "minor" "0.2.0"
+          "patch" "0.1.1"))
+      (testing "with prefix"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+                                                      :input/tag-prefix "v")
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "v1.0.0"
+          "minor" "v0.2.0"
+          "patch" "v0.1.1")))
+
+    (testing "body"
+      (testing ":input/release-body"
+        (is (= "Version 0.2.0
+
+Hello World
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+"
+               (-> (assoc ctx :input/release-body "Hello World\n")
+                   (sut/generate-new-release-data related-data)
+                   (get :body)))))
+      (testing ":input/max-commits"
+        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :body)
+                                                      (str/split-lines)
+                                                      (last)))
+          1   "- [946550e6] Commit 10"
+          5   "- [74ffa7bf] Commit 7" ;commits are limited to range *after* 536a71ab
+          10  "- [74ffa7bf] Commit 7"
+          11  "- [74ffa7bf] Commit 7"
+          100 "- [74ffa7bf] Commit 7" ;larger number than what's available
+          )))))


### PR DESCRIPTION
The integration tests now have stable assertions by using these repositories as fixtures.

1. https://github.com/release-on-push-action/test-project-without-releases
2. https://github.com/release-on-push-action/test-project-with-release

Fixes #55.

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level