### PR TITLE
Add Release Name customization

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: docker build . -t rymndhng/release-on-push-action
 
       - name: Container Test
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e INPUT_RELEASE_NAME -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
         env:
           INPUT_BUMP_VERSION_SCHEME: minor
           INPUT_MAX_COMMITS: 5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,6 +37,7 @@ jobs:
           INPUT_BUMP_VERSION_SCHEME: minor
           INPUT_MAX_COMMITS: 5
           INPUT_TAG_PREFIX: v
+          INPUT_RELEASE_NAME: <RELEASE_TAG>
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check Output Parameters
@@ -54,6 +55,7 @@ jobs:
           INPUT_BUMP_VERSION_SCHEME: minor
           INPUT_MAX_COMMITS: 5
           INPUT_TAG_PREFIX: v
+          INPUT_RELEASE_NAME: <RELEASE_TAG>
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Disable me if needed to debug curl/post action

--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ jobs:
           tag_prefix: ""
 ```
 
+### Can I change the prefix `v` from the Git Release?
+
+Yes, you can customize this by changing the `release_prefix`. Here's an example of
+removing the prefix from the release name by using an empty string but still leaving the prefix for the tag name.
+ 
+``` yaml
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          tag_prefix: "v"
+          release_prefix: ""
+```
+
 ### How can I configure the maximum number of commits to summarize?
 
 Use the option `max_commits`. The default value is 50.

--- a/README.md
+++ b/README.md
@@ -184,11 +184,15 @@ jobs:
           tag_prefix: ""
 ```
 
-### Can I change the prefix `v` from the Git Release?
+### Can I change the name of the Release?
 
-Yes, you can customize this by changing the `release_prefix`. Here's an example of
-removing the prefix from the release name by using an empty string but still leaving the prefix for the tag name.
- 
+Yes, you can customize this by changing the `release_name`. The `release_name` supports these template variables:
+
+- `<RELEASE_VERSION>` contains the version number, i.e. `1.2.3`
+- `<RELEASE_TAG>` contains the git tag name, i.e. `v1.2.3`
+
+See example below for how to create a release with the name `Release 1.2.3`
+
 ``` yaml
 on:
   push:
@@ -204,7 +208,7 @@ jobs:
       - uses: rymndhng/release-on-push-action@master
         with:
           tag_prefix: "v"
-          release_prefix: ""
+          release_name: "Release <RELEASE_VERSION>"
 ```
 
 ### How can I configure the maximum number of commits to summarize?

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,14 @@ inputs:
     description: "Prefix to append to git tags. To unset this, set version_prefix to an empty string."
     required: false
     default: 'v'
-  release_prefix:
-    description: "Prefix to append to git release name. To unset this, set version_prefix to an empty string."
-    required: false
-    default: 'v'
+  release_name:
+    description: |
+      Name of the release. Supports these template variables:
+
+        <RELEASE_VERSION> the version number, e.g. "1.2.3"
+        <RELEASE_TAG>     the git tag name, e.g. "v1.2.3"
+    required: true
+    default: '<RELEASE_TAG>'
   max_commits:
     description: "Maximum number of commits to add to release body"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Prefix to append to git tags. To unset this, set version_prefix to an empty string."
     required: false
     default: 'v'
+  release_prefix:
+    description: "Prefix to append to git release name. To unset this, set version_prefix to an empty string."
+    required: false
+    default: 'v'
   max_commits:
     description: "Maximum number of commits to add to release body"
     required: false

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -39,6 +39,7 @@
    :input/max-commits   (Integer/parseInt (getenv-or-throw "INPUT_MAX_COMMITS"))
    :input/release-body  (System/getenv "INPUT_RELEASE_BODY")
    :input/tag-prefix    (System/getenv "INPUT_TAG_PREFIX") ;defaults to "v", see default in action.yml
+   :input/release-prefix (System/getenv "INPUT_RELEASE_PREFIX") ;defaults to "v", see default in action.yml
    :input/use-github-release-notes (Boolean/parseBoolean (System/getenv "INPUT_USE_GITHUB_RELEASE_NOTES"))
    :bump-version-scheme (assert-valid-bump-version-scheme
                          (try
@@ -122,7 +123,7 @@
 
     {:tag_name               (str (:input/tag-prefix context) next-version)
      :target_commitish       (:sha context)
-     :name                   (str (:input/tag-prefix context) next-version)
+     :name                   (str (:input/release-prefix context) next-version)
      :body                   body
      :draft                  false
      :prerelease             false

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -49,6 +49,7 @@
    :input/release-body  ""
    :input/tag-prefix    ""
    :input/use-github-release-notes false
+   :input/release-name  "<RELEASE_TAG>"
    :bump-version-scheme "minor"
    :dry-run             true})
 
@@ -111,6 +112,17 @@
           "minor" "v0.1.0"
           "patch" "v0.0.1")))
 
+    (testing "release_name"
+      (are [template expected] (= expected (-> (assoc ctx
+                                                      :input/tag-prefix "v"
+                                                      :input/release-name template)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :name)))
+        "<RELEASE_TAG>"                           "v0.1.0"
+        "<RELEASE_VERSION>"                       "0.1.0"
+        "Release <RELEASE_VERSION>"               "Release 0.1.0"
+        "Release <RELEASE_TAG> <RELEASE_VERSION>" "Release v0.1.0 0.1.0"))
+
     (testing "body"
       (testing ":input/release-body"
         (is (= "Version 0.1.0
@@ -139,7 +151,7 @@ Hello World
           5   "- [536a71ab] Commit 6"
           10  "- [8c0eef57] Commit 1"
           11  "- [2db43d3a] Initial commit"
-          100 "- [2db43d3a] Initial commit"     ;larger number than what's available
+          100 "- [2db43d3a] Initial commit" ;larger number than what's available
           )))))
 
 (deftest ^:integration generate-new-release-data-from-existing-release


### PR DESCRIPTION
Adding some additional customization to be able to customize the release name instead of just using the tag name


# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level