### PR TITLE
Expose --dry-run via `input.dry_run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Allowed values of `bump_version_scheme`:
 
 For stability, we recommend pinning the version of the action. See [Releases](https://github.com/rymndhng/release-on-push-action/releases).
 
+See [action.yml](./action.yml) for the full list of options.
+
 ## FAQ
 
 ### Can I skip creation of a release?

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "When set to 'true', uses Github's Generated Release Notes instead of this plugin's release notes"
     required: false
     default: "false"
+  dry_run:
+    description: "When set to 'true', will compute the next tag, but will not create a release."
+    required: false
+    default: "false"
 outputs:
   tag_name:
     description: 'Tag of released version'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -49,7 +49,8 @@
                              (if (input-strategy-set?)
                                (getenv-or-throw "INPUT_STRATEGY")
                                (throw ex)))))
-   :dry-run             (contains? (set args) "--dry-run")})
+   :dry-run             (or (Boolean/parseBoolean (System/getenv "INPUT_DRY_RUN"))
+                            (contains? (set args) "--dry-run"))})
 
 ;; -- Version Bumping Logic  ---------------------------------------------------
 (defn fetch-related-data [context]


### PR DESCRIPTION
Fixes #70

# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level