### PR TITLE
Update FAQ on permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Only one of these labels should be present on a PR. If there are multiple, the b
 
 ### Do I need to setup Github Action access tokens or any other permission-related thing?
 
-No, you do not! Github Actions will inject a token for this plugin to interact with the API. 
+Github Actions will inject a token for this plugin to interact with the API.
+You need to enable `read and write permission` to this token under `settings > actions > general > workflow permissions` (disabled by default).
 
 ### Can I create a tag instead of a release?
 


### PR DESCRIPTION
This action cannot create a new release if the option `read and write permission` is not enabled under `settings > actions > general > workflow permissions`, which is disabled by default. (getting error `Resource not accessible by integration`)

I updated the FAQ section in README accordingly.



# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level