### PR TITLE
fix: Use pulls API instead of search API

### DIFF
--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -62,7 +62,7 @@
                               (:body (github/fetch-commit (assoc context :sha tag))))}))
 
 (defn get-labels [related-prs]
-  (->> related-prs :items (map :labels) flatten (map :name) set))
+  (->> related-prs (map :labels) flatten (map :name) set))
 
 (defn bump-version-scheme [context related-data]
   (let [labels (get-labels (:related-prs related-data))]

--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -43,12 +43,14 @@
 
 ;; -- Github PRs API  ----------------------------------------------------------
 (defn fetch-related-prs
-  "See https://developer.github.com/v3/pulls/#list-pull-requests"
+  "See https://docs.github.com/en/rest/commits/commits#list-pull-requests-associated-with-a-commit"
   [context]
   (parse-response
-   (curl/get (format "%s/search/issues" (:github/api-url context))
-             {:headers      (headers context)
-              :query-params {"q" (format "repo:%s type:pr is:closed is:merged SHA:%s" (:repo context) (:sha context))}})))
+   (curl/get (format "%s/repos/%s/commits/%s/pulls"
+                     (:github/api-url context)
+                     (:repo context)
+                     (:sha context))
+             {:headers (headers context)})))
 
 ;; -- Github Releases API  -----------------------------------------------------
 (defn fetch-latest-release

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -76,7 +76,7 @@
 (deftest ^:integration generate-new-release-data-from-new-project
   (let [[ctx related-data] @fixture-project-without-release]
     (testing "preconditions"
-      (is (= 0 (get-in related-data [:related-prs :total_count])))
+      (is (= 0 (count (get-in related-data [:related-prs]))))
       (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
       (is (nil? (:latest-release related-data)) "has no latest release"))
 
@@ -157,7 +157,7 @@ Hello World
 (deftest ^:integration generate-new-release-data-from-existing-release
   (let [[ctx related-data] @fixture-project-with-release]
     (testing "preconditions"
-      (is (= 0 (get-in related-data [:related-prs :total_count])))
+      (is (= 0 (count (get-in related-data [:related-prs]))))
       (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
       (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
 


### PR DESCRIPTION
I ran into the secondary rate limit issue in this Github Actions. From deeper investigation, it appears the code for fetching PRs has a tighter rate limit than the past.

From investigation, it appears that switching to the pulls API should avoid the rate limit on the search API.

This should fix #73.

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [x] Have set labels for release level