### PR TITLE
Support prerelease

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: 'Creates a Tag/Release on Push. Generates Release Notes. Customizab
 author: 'rymndhng'
 inputs:
   bump_version_scheme:
-    description: 'The bumping scheme to use by default. One of minor|major|patch|norelease'
+    description: 'The bumping scheme to use by default. One of minor|major|patch|prerelease|norelease'
     required: true
   release_body:
     description: "Additional text to insert into the release's body."

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "When set to 'true', will compute the next tag, but will not create a release."
     required: false
     default: "false"
+  prerelease_tag:
+    description: "The tag to use for prerelease versions. For example a tag of 'pre': 1.0.0-pre.1."
+    required: false
+    default: "pre"
 outputs:
   tag_name:
     description: 'Tag of released version'

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -55,7 +55,7 @@
 
 ;; -- Version Bumping Logic  ---------------------------------------------------
 (defn fetch-related-data [context]
-  (let [latest-release (:body (github/fetch-latest-release context))]
+  (let [latest-release (first (:body (github/fetch-releases context)))]
     {:related-prs           (:body (github/fetch-related-prs context))
      :commit                (:body (github/fetch-commit context))
      :latest-release        latest-release

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -71,6 +71,7 @@
       (contains? labels "release:major") :major
       (contains? labels "release:minor") :minor
       (contains? labels "release:patch") :patch
+      (contains? labels "prerelease") :prerelease
       :else (keyword (:bump-version-scheme context)))))
 
 (defn is-prerelease? [context related-data]
@@ -92,7 +93,8 @@
                        :major [(safe-inc major) 0 0]
                        :minor [major (safe-inc minor) 0]
                        :patch [major minor (safe-inc patch)]
-                       :norelease [major minor patch])]
+                       :norelease [major minor patch]
+                       :prerelease [major minor patch])]
     (str (str/join "." next-version) (if prerelease-version (str "-" prerelease-version)))))
 
 (defn prerelease-bump [version prerelease-tag]
@@ -108,6 +110,8 @@
 
 (defn norelease-reason [context related-data]
   (cond
+    (is-prerelease? context related-data) nil
+
     (= :norelease (bump-version-scheme context related-data))
     "Skipping release, no version bump found."
 

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -81,12 +81,14 @@
   (inc (or n 0)))
 
 (defn semver-bump [version bump]
-  (let [[major minor patch] (map #(Integer/parseInt %) (str/split version #"\."))
+  (let [[main-version prerelease-version] (str/split version #"-")
+        [major minor patch] (map #(Integer/parseInt %) (str/split main-version #"\."))
         next-version (condp = bump
                        :major [(safe-inc major) 0 0]
                        :minor [major (safe-inc minor) 0]
-                       :patch [major minor (safe-inc patch)])]
-    (str/join "." next-version)))
+                       :patch [major minor (safe-inc patch)]
+                       :norelease [major minor patch])]
+    (str (str/join "." next-version) (if prerelease-version (str "-" prerelease-version)))))
 
 (defn norelease-reason [context related-data]
   (cond

--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -71,6 +71,24 @@
 
         :else (throw ex)))))
 
+(defn fetch-releases
+  "Gets releases. Returns nil when there are no releases.
+
+  See https://developer.github.com/v3/repos/releases/#list-releases"
+  [context]
+  (try
+    (parse-response
+     (curl/get
+      (format "%s/repos/%s/releases" (:github/api-url context) (:repo context))
+      {:headers (headers context)}))
+    (catch clojure.lang.ExceptionInfo ex
+      (cond
+        ;; No previous release created, return nil
+        (= 404 (:status (ex-data ex)))
+        (println "No releases found for project.")
+
+        :else (throw ex)))))
+
 ;; -- Github Commit API  -------------------------------------------------------
 (defn fetch-commit
   "See https://developer.github.com/v3/repos/commits/"

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -21,26 +21,65 @@
     "foo<<EOF\nhello\rworld\nEOF"  "hello\rworld"))
 
 (deftest semver-bump
+  (testing "norelease bump"
+    (are [expected input] (= expected (sut/semver-bump input :norelease))
+        "0.0.0" "0.0.0"
+        "0.0.0-pre" "0.0.0-pre"
+        "0.0.0-pre.1" "0.0.0-pre.1"
+        "0.0.1" "0.0.1"
+        "0.0.1-pre" "0.0.1-pre"
+        "0.0.1-pre.1" "0.0.1-pre.1"
+        "0.1.0" "0.1.0"
+        "0.1.0-pre" "0.1.0-pre"
+        "0.1.0-pre.1" "0.1.0-pre.1"
+        "1.1.0" "1.1.0"
+        "1.1.0-pre" "1.1.0-pre"
+        "1.1.0-pre.1" "1.1.0-pre.1"))
+
   (testing "patch bump"
     (are [expected input] (= expected (sut/semver-bump input :patch))
         "0.0.1" "0.0.0"
+        "0.0.1-pre" "0.0.0-pre"
+        "0.0.1-pre.1" "0.0.0-pre.1"
         "0.0.2" "0.0.1"
+        "0.0.2-pre" "0.0.1-pre"
+        "0.0.2-pre.1" "0.0.1-pre.1"
         "0.1.1" "0.1.0"
-        "1.1.1" "1.1.0"))
+        "0.1.1-pre" "0.1.0-pre"
+        "0.1.1-pre.1" "0.1.0-pre.1"
+        "1.1.1" "1.1.0"
+        "1.1.1-pre" "1.1.0-pre"
+        "1.1.1-pre.1" "1.1.0-pre.1"))
 
   (testing "minor bump"
     (are [expected input] (= expected (sut/semver-bump input :minor))
         "0.1.0" "0.0.0"
+        "0.1.0-pre" "0.0.0-pre"
+        "0.1.0-pre.1" "0.0.0-pre.1"
         "0.1.0" "0.0.1"
+        "0.1.0-pre" "0.0.1-pre"
+        "0.1.0-pre.1" "0.0.1-pre.1"
         "0.2.0" "0.1.0"
-        "1.2.0" "1.1.0"))
+        "0.2.0-pre" "0.1.0-pre"
+        "0.2.0-pre.1" "0.1.0-pre.1"
+        "1.2.0" "1.1.0"
+        "1.2.0-pre" "1.1.0-pre"
+        "1.2.0-pre.1" "1.1.0-pre.1"))
 
   (testing "major bump"
     (are [expected input] (= expected (sut/semver-bump input :major))
       "1.0.0" "0.0.0"
+      "1.0.0-pre" "0.0.0-pre"
+      "1.0.0-pre.1" "0.0.0-pre.1"
       "1.0.0" "0.0.1"
+      "1.0.0-pre" "0.0.1-pre"
+      "1.0.0-pre.1" "0.0.1-pre.1"
       "1.0.0" "0.1.0"
-      "2.0.0" "1.1.0")))
+      "1.0.0-pre" "0.1.0-pre"
+      "1.0.0-pre.1" "0.1.0-pre.1"
+      "2.0.0" "1.1.0"
+      "2.0.0-pre" "1.1.0-pre"
+      "2.0.0-pre.1" "1.1.0-pre.1")))
 
 (def base-ctx
   {:token               (System/getenv "GITHUB_TOKEN") ;use Github Actions Token as test token
@@ -73,161 +112,161 @@
   :repo "release-on-push-action/test-project-with-release"
   :sha "946550e635d4bae50cb5cec434678b439b59c659")
 
-(deftest ^:integration generate-new-release-data-from-new-project
-  (let [[ctx related-data] @fixture-project-without-release]
-    (testing "preconditions"
-      (is (= 0 (count (get-in related-data [:related-prs]))))
-      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
-      (is (nil? (:latest-release related-data)) "has no latest release"))
+;(deftest ^:integration generate-new-release-data-from-new-project
+;  (let [[ctx related-data] @fixture-project-without-release]
+;    (testing "preconditions"
+;      (is (= 0 (count (get-in related-data [:related-prs]))))
+;      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+;      (is (nil? (:latest-release related-data)) "has no latest release"))
+;
+;    (testing "generate-new-release-data"
+;      (let [release-data (sut/generate-new-release-data ctx related-data)]
+;        (are [key expected] (= expected (get release-data key))
+;          :tag_name "0.1.0"
+;          :body     "Version 0.1.0
+;
+;### Commits
+;
+;- [946550e6] Commit 10
+;- [de6b1b7a] Commit 9
+;- [2af2e1d6] Commit 8
+;- [74ffa7bf] Commit 7
+;- [536a71ab] Commit 6
+;")))
+;
+;    (testing "tag_name"
+;      (testing ":bump-version-scheme"
+;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+;                                               (sut/generate-new-release-data related-data)
+;                                               (get :tag_name)))
+;          "major" "1.0.0"
+;          "minor" "0.1.0"
+;          "patch" "0.0.1"))
+;      (testing "with prefix"
+;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+;                                                          :input/tag-prefix "v")
+;                                               (sut/generate-new-release-data related-data)
+;                                               (get :tag_name)))
+;          "major" "v1.0.0"
+;          "minor" "v0.1.0"
+;          "patch" "v0.0.1")))
+;
+;    (testing "release_name"
+;      (are [template expected] (= expected (-> (assoc ctx
+;                                                      :input/tag-prefix "v"
+;                                                      :input/release-name template)
+;                                               (sut/generate-new-release-data related-data)
+;                                               (get :name)))
+;        "<RELEASE_TAG>"                           "v0.1.0"
+;        "<RELEASE_VERSION>"                       "0.1.0"
+;        "Release <RELEASE_VERSION>"               "Release 0.1.0"
+;        "Release <RELEASE_TAG> <RELEASE_VERSION>" "Release v0.1.0 0.1.0"))
+;
+;    (testing "body"
+;      (testing ":input/release-body"
+;        (is (= "Version 0.1.0
+;
+;Hello World
+;
+;### Commits
+;
+;- [946550e6] Commit 10
+;- [de6b1b7a] Commit 9
+;- [2af2e1d6] Commit 8
+;- [74ffa7bf] Commit 7
+;- [536a71ab] Commit 6
+;"
+;               (-> (assoc ctx :input/release-body "Hello World")
+;                   (sut/generate-new-release-data related-data)
+;                   (get :body)))))
+;
+;      (testing ":input/max-commits"
+;        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+;                                                      (sut/generate-new-release-data related-data)
+;                                                      (get :body)
+;                                                      (str/split-lines)
+;                                                      (last)))
+;          1   "- [946550e6] Commit 10"
+;          5   "- [536a71ab] Commit 6"
+;          10  "- [8c0eef57] Commit 1"
+;          11  "- [2db43d3a] Initial commit"
+;          100 "- [2db43d3a] Initial commit" ;larger number than what's available
+;          )))))
 
-    (testing "generate-new-release-data"
-      (let [release-data (sut/generate-new-release-data ctx related-data)]
-        (are [key expected] (= expected (get release-data key))
-          :tag_name "0.1.0"
-          :body     "Version 0.1.0
+;(deftest ^:integration generate-new-release-data-from-existing-release
+;  (let [[ctx related-data] @fixture-project-with-release]
+;    (testing "preconditions"
+;      (is (= 0 (count (get-in related-data [:related-prs]))))
+;      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+;      (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
+;
+;    (testing "generate-new-release-data"
+;      (let [release-data (sut/generate-new-release-data ctx related-data)]
+;        (are [key expected] (= expected (get release-data key))
+;          :tag_name "0.2.0"
+;
+;          ;; note that commit 6 is not included here
+;          :body "Version 0.2.0
+;
+;### Commits
+;
+;- [946550e6] Commit 10
+;- [de6b1b7a] Commit 9
+;- [2af2e1d6] Commit 8
+;- [74ffa7bf] Commit 7
+;")))
+;
+;    (testing "tag_name"
+;      (testing ":bump-version-scheme"
+;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+;                                               (sut/generate-new-release-data related-data)
+;                                               (get :tag_name)))
+;          "major" "1.0.0"
+;          "minor" "0.2.0"
+;          "patch" "0.1.1"))
+;      (testing "with prefix"
+;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+;                                                      :input/tag-prefix "v")
+;                                               (sut/generate-new-release-data related-data)
+;                                               (get :tag_name)))
+;          "major" "v1.0.0"
+;          "minor" "v0.2.0"
+;          "patch" "v0.1.1")))
+;
+;    (testing "body"
+;      (testing ":input/release-body"
+;        (is (= "Version 0.2.0
+;
+;Hello World
+;
+;### Commits
+;
+;- [946550e6] Commit 10
+;- [de6b1b7a] Commit 9
+;- [2af2e1d6] Commit 8
+;- [74ffa7bf] Commit 7
+;"
+;               (-> (assoc ctx :input/release-body "Hello World")
+;                   (sut/generate-new-release-data related-data)
+;                   (get :body)))))
+;      (testing ":input/max-commits"
+;        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+;                                                      (sut/generate-new-release-data related-data)
+;                                                      (get :body)
+;                                                      (str/split-lines)
+;                                                      (last)))
+;          1   "- [946550e6] Commit 10"
+;          5   "- [74ffa7bf] Commit 7" ;commits are limited to range *after* 536a71ab
+;          10  "- [74ffa7bf] Commit 7"
+;          11  "- [74ffa7bf] Commit 7"
+;          100 "- [74ffa7bf] Commit 7" ;larger number than what's available
+;          )))))
 
-### Commits
-
-- [946550e6] Commit 10
-- [de6b1b7a] Commit 9
-- [2af2e1d6] Commit 8
-- [74ffa7bf] Commit 7
-- [536a71ab] Commit 6
-")))
-
-    (testing "tag_name"
-      (testing ":bump-version-scheme"
-        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
-                                               (sut/generate-new-release-data related-data)
-                                               (get :tag_name)))
-          "major" "1.0.0"
-          "minor" "0.1.0"
-          "patch" "0.0.1"))
-      (testing "with prefix"
-        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
-                                                          :input/tag-prefix "v")
-                                               (sut/generate-new-release-data related-data)
-                                               (get :tag_name)))
-          "major" "v1.0.0"
-          "minor" "v0.1.0"
-          "patch" "v0.0.1")))
-
-    (testing "release_name"
-      (are [template expected] (= expected (-> (assoc ctx
-                                                      :input/tag-prefix "v"
-                                                      :input/release-name template)
-                                               (sut/generate-new-release-data related-data)
-                                               (get :name)))
-        "<RELEASE_TAG>"                           "v0.1.0"
-        "<RELEASE_VERSION>"                       "0.1.0"
-        "Release <RELEASE_VERSION>"               "Release 0.1.0"
-        "Release <RELEASE_TAG> <RELEASE_VERSION>" "Release v0.1.0 0.1.0"))
-
-    (testing "body"
-      (testing ":input/release-body"
-        (is (= "Version 0.1.0
-
-Hello World
-
-### Commits
-
-- [946550e6] Commit 10
-- [de6b1b7a] Commit 9
-- [2af2e1d6] Commit 8
-- [74ffa7bf] Commit 7
-- [536a71ab] Commit 6
-"
-               (-> (assoc ctx :input/release-body "Hello World")
-                   (sut/generate-new-release-data related-data)
-                   (get :body)))))
-
-      (testing ":input/max-commits"
-        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
-                                                      (sut/generate-new-release-data related-data)
-                                                      (get :body)
-                                                      (str/split-lines)
-                                                      (last)))
-          1   "- [946550e6] Commit 10"
-          5   "- [536a71ab] Commit 6"
-          10  "- [8c0eef57] Commit 1"
-          11  "- [2db43d3a] Initial commit"
-          100 "- [2db43d3a] Initial commit" ;larger number than what's available
-          )))))
-
-(deftest ^:integration generate-new-release-data-from-existing-release
-  (let [[ctx related-data] @fixture-project-with-release]
-    (testing "preconditions"
-      (is (= 0 (count (get-in related-data [:related-prs]))))
-      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
-      (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
-
-    (testing "generate-new-release-data"
-      (let [release-data (sut/generate-new-release-data ctx related-data)]
-        (are [key expected] (= expected (get release-data key))
-          :tag_name "0.2.0"
-
-          ;; note that commit 6 is not included here
-          :body "Version 0.2.0
-
-### Commits
-
-- [946550e6] Commit 10
-- [de6b1b7a] Commit 9
-- [2af2e1d6] Commit 8
-- [74ffa7bf] Commit 7
-")))
-
-    (testing "tag_name"
-      (testing ":bump-version-scheme"
-        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
-                                               (sut/generate-new-release-data related-data)
-                                               (get :tag_name)))
-          "major" "1.0.0"
-          "minor" "0.2.0"
-          "patch" "0.1.1"))
-      (testing "with prefix"
-        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
-                                                      :input/tag-prefix "v")
-                                               (sut/generate-new-release-data related-data)
-                                               (get :tag_name)))
-          "major" "v1.0.0"
-          "minor" "v0.2.0"
-          "patch" "v0.1.1")))
-
-    (testing "body"
-      (testing ":input/release-body"
-        (is (= "Version 0.2.0
-
-Hello World
-
-### Commits
-
-- [946550e6] Commit 10
-- [de6b1b7a] Commit 9
-- [2af2e1d6] Commit 8
-- [74ffa7bf] Commit 7
-"
-               (-> (assoc ctx :input/release-body "Hello World")
-                   (sut/generate-new-release-data related-data)
-                   (get :body)))))
-      (testing ":input/max-commits"
-        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
-                                                      (sut/generate-new-release-data related-data)
-                                                      (get :body)
-                                                      (str/split-lines)
-                                                      (last)))
-          1   "- [946550e6] Commit 10"
-          5   "- [74ffa7bf] Commit 7" ;commits are limited to range *after* 536a71ab
-          10  "- [74ffa7bf] Commit 7"
-          11  "- [74ffa7bf] Commit 7"
-          100 "- [74ffa7bf] Commit 7" ;larger number than what's available
-          )))))
-
-(deftest ^:integration generate-new-release-data-with-github-generated-release-notes
-  (let [[ctx related-data] @fixture-project-with-release
-        ctx                (assoc ctx :input/use-github-release-notes true)
-        release-data       (sut/generate-new-release-data ctx related-data)]
-
-    (testing "sets options to enable Github Generated Release Notes"
-      (is (= true (:generate_release_notes release-data)))
-      (is (= "Version 0.2.0\n\n" (:body release-data))))))
+;(deftest ^:integration generate-new-release-data-with-github-generated-release-notes
+;  (let [[ctx related-data] @fixture-project-with-release
+;        ctx                (assoc ctx :input/use-github-release-notes true)
+;        release-data       (sut/generate-new-release-data ctx related-data)]
+;
+;    (testing "sets options to enable Github Generated Release Notes"
+;      (is (= true (:generate_release_notes release-data)))
+;      (is (= "Version 0.2.0\n\n" (:body release-data))))))

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -20,6 +20,19 @@
     "foo<<EOF\nhello\nworld\nEOF"  "hello\nworld"
     "foo<<EOF\nhello\rworld\nEOF"  "hello\rworld"))
 
+(deftest prerelease-bump
+  (testing "prerelease bump"
+    (are [expected input] (= expected (sut/prerelease-bump input "pre"))
+        "0.0.0-pre" "0.0.0"
+        "0.0.0-pre.1" "0.0.0-pre"
+        "0.0.1-pre" "0.0.1"
+        "0.0.1-pre.1" "0.0.1-pre"
+        "0.1.0-pre" "0.1.0"
+        "0.1.0-pre.1" "0.1.0-pre"
+        "1.1.0-pre" "1.1.0"
+        "1.1.0-pre.1" "1.1.0-pre"
+        "1.1.0-pre.2" "1.1.0-pre.1")))
+
 (deftest semver-bump
   (testing "norelease bump"
     (are [expected input] (= expected (sut/semver-bump input :norelease))

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -125,161 +125,161 @@
   :repo "release-on-push-action/test-project-with-release"
   :sha "946550e635d4bae50cb5cec434678b439b59c659")
 
-;(deftest ^:integration generate-new-release-data-from-new-project
-;  (let [[ctx related-data] @fixture-project-without-release]
-;    (testing "preconditions"
-;      (is (= 0 (count (get-in related-data [:related-prs]))))
-;      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
-;      (is (nil? (:latest-release related-data)) "has no latest release"))
-;
-;    (testing "generate-new-release-data"
-;      (let [release-data (sut/generate-new-release-data ctx related-data)]
-;        (are [key expected] (= expected (get release-data key))
-;          :tag_name "0.1.0"
-;          :body     "Version 0.1.0
-;
-;### Commits
-;
-;- [946550e6] Commit 10
-;- [de6b1b7a] Commit 9
-;- [2af2e1d6] Commit 8
-;- [74ffa7bf] Commit 7
-;- [536a71ab] Commit 6
-;")))
-;
-;    (testing "tag_name"
-;      (testing ":bump-version-scheme"
-;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
-;                                               (sut/generate-new-release-data related-data)
-;                                               (get :tag_name)))
-;          "major" "1.0.0"
-;          "minor" "0.1.0"
-;          "patch" "0.0.1"))
-;      (testing "with prefix"
-;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
-;                                                          :input/tag-prefix "v")
-;                                               (sut/generate-new-release-data related-data)
-;                                               (get :tag_name)))
-;          "major" "v1.0.0"
-;          "minor" "v0.1.0"
-;          "patch" "v0.0.1")))
-;
-;    (testing "release_name"
-;      (are [template expected] (= expected (-> (assoc ctx
-;                                                      :input/tag-prefix "v"
-;                                                      :input/release-name template)
-;                                               (sut/generate-new-release-data related-data)
-;                                               (get :name)))
-;        "<RELEASE_TAG>"                           "v0.1.0"
-;        "<RELEASE_VERSION>"                       "0.1.0"
-;        "Release <RELEASE_VERSION>"               "Release 0.1.0"
-;        "Release <RELEASE_TAG> <RELEASE_VERSION>" "Release v0.1.0 0.1.0"))
-;
-;    (testing "body"
-;      (testing ":input/release-body"
-;        (is (= "Version 0.1.0
-;
-;Hello World
-;
-;### Commits
-;
-;- [946550e6] Commit 10
-;- [de6b1b7a] Commit 9
-;- [2af2e1d6] Commit 8
-;- [74ffa7bf] Commit 7
-;- [536a71ab] Commit 6
-;"
-;               (-> (assoc ctx :input/release-body "Hello World")
-;                   (sut/generate-new-release-data related-data)
-;                   (get :body)))))
-;
-;      (testing ":input/max-commits"
-;        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
-;                                                      (sut/generate-new-release-data related-data)
-;                                                      (get :body)
-;                                                      (str/split-lines)
-;                                                      (last)))
-;          1   "- [946550e6] Commit 10"
-;          5   "- [536a71ab] Commit 6"
-;          10  "- [8c0eef57] Commit 1"
-;          11  "- [2db43d3a] Initial commit"
-;          100 "- [2db43d3a] Initial commit" ;larger number than what's available
-;          )))))
+(deftest ^:integration generate-new-release-data-from-new-project
+  (let [[ctx related-data] @fixture-project-without-release]
+    (testing "preconditions"
+      (is (= 0 (count (get-in related-data [:related-prs]))))
+      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+      (is (nil? (:latest-release related-data)) "has no latest release"))
 
-;(deftest ^:integration generate-new-release-data-from-existing-release
-;  (let [[ctx related-data] @fixture-project-with-release]
-;    (testing "preconditions"
-;      (is (= 0 (count (get-in related-data [:related-prs]))))
-;      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
-;      (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
-;
-;    (testing "generate-new-release-data"
-;      (let [release-data (sut/generate-new-release-data ctx related-data)]
-;        (are [key expected] (= expected (get release-data key))
-;          :tag_name "0.2.0"
-;
-;          ;; note that commit 6 is not included here
-;          :body "Version 0.2.0
-;
-;### Commits
-;
-;- [946550e6] Commit 10
-;- [de6b1b7a] Commit 9
-;- [2af2e1d6] Commit 8
-;- [74ffa7bf] Commit 7
-;")))
-;
-;    (testing "tag_name"
-;      (testing ":bump-version-scheme"
-;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
-;                                               (sut/generate-new-release-data related-data)
-;                                               (get :tag_name)))
-;          "major" "1.0.0"
-;          "minor" "0.2.0"
-;          "patch" "0.1.1"))
-;      (testing "with prefix"
-;        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
-;                                                      :input/tag-prefix "v")
-;                                               (sut/generate-new-release-data related-data)
-;                                               (get :tag_name)))
-;          "major" "v1.0.0"
-;          "minor" "v0.2.0"
-;          "patch" "v0.1.1")))
-;
-;    (testing "body"
-;      (testing ":input/release-body"
-;        (is (= "Version 0.2.0
-;
-;Hello World
-;
-;### Commits
-;
-;- [946550e6] Commit 10
-;- [de6b1b7a] Commit 9
-;- [2af2e1d6] Commit 8
-;- [74ffa7bf] Commit 7
-;"
-;               (-> (assoc ctx :input/release-body "Hello World")
-;                   (sut/generate-new-release-data related-data)
-;                   (get :body)))))
-;      (testing ":input/max-commits"
-;        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
-;                                                      (sut/generate-new-release-data related-data)
-;                                                      (get :body)
-;                                                      (str/split-lines)
-;                                                      (last)))
-;          1   "- [946550e6] Commit 10"
-;          5   "- [74ffa7bf] Commit 7" ;commits are limited to range *after* 536a71ab
-;          10  "- [74ffa7bf] Commit 7"
-;          11  "- [74ffa7bf] Commit 7"
-;          100 "- [74ffa7bf] Commit 7" ;larger number than what's available
-;          )))))
+    (testing "generate-new-release-data"
+      (let [release-data (sut/generate-new-release-data ctx related-data)]
+        (are [key expected] (= expected (get release-data key))
+          :tag_name "0.1.0"
+          :body     "Version 0.1.0
 
-;(deftest ^:integration generate-new-release-data-with-github-generated-release-notes
-;  (let [[ctx related-data] @fixture-project-with-release
-;        ctx                (assoc ctx :input/use-github-release-notes true)
-;        release-data       (sut/generate-new-release-data ctx related-data)]
-;
-;    (testing "sets options to enable Github Generated Release Notes"
-;      (is (= true (:generate_release_notes release-data)))
-;      (is (= "Version 0.2.0\n\n" (:body release-data))))))
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+- [536a71ab] Commit 6
+")))
+
+    (testing "tag_name"
+      (testing ":bump-version-scheme"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "1.0.0"
+          "minor" "0.1.0"
+          "patch" "0.0.1"))
+      (testing "with prefix"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+                                                          :input/tag-prefix "v")
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "v1.0.0"
+          "minor" "v0.1.0"
+          "patch" "v0.0.1")))
+
+    (testing "release_name"
+      (are [template expected] (= expected (-> (assoc ctx
+                                                      :input/tag-prefix "v"
+                                                      :input/release-name template)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :name)))
+        "<RELEASE_TAG>"                           "v0.1.0"
+        "<RELEASE_VERSION>"                       "0.1.0"
+        "Release <RELEASE_VERSION>"               "Release 0.1.0"
+        "Release <RELEASE_TAG> <RELEASE_VERSION>" "Release v0.1.0 0.1.0"))
+
+    (testing "body"
+      (testing ":input/release-body"
+        (is (= "Version 0.1.0
+
+Hello World
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+- [536a71ab] Commit 6
+"
+               (-> (assoc ctx :input/release-body "Hello World")
+                   (sut/generate-new-release-data related-data)
+                   (get :body)))))
+
+      (testing ":input/max-commits"
+        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :body)
+                                                      (str/split-lines)
+                                                      (last)))
+          1   "- [946550e6] Commit 10"
+          5   "- [536a71ab] Commit 6"
+          10  "- [8c0eef57] Commit 1"
+          11  "- [2db43d3a] Initial commit"
+          100 "- [2db43d3a] Initial commit" ;larger number than what's available
+          )))))
+
+(deftest ^:integration generate-new-release-data-from-existing-release
+  (let [[ctx related-data] @fixture-project-with-release]
+    (testing "preconditions"
+      (is (= 0 (count (get-in related-data [:related-prs]))))
+      (is (= "Commit 10" (get-in related-data [:commit :commit :message])))
+      (is (= "v0.1.0" (get-in related-data [:latest-release :tag_name])) "has release v0.1.0"))
+
+    (testing "generate-new-release-data"
+      (let [release-data (sut/generate-new-release-data ctx related-data)]
+        (are [key expected] (= expected (get release-data key))
+          :tag_name "0.2.0"
+
+          ;; note that commit 6 is not included here
+          :body "Version 0.2.0
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+")))
+
+    (testing "tag_name"
+      (testing ":bump-version-scheme"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "1.0.0"
+          "minor" "0.2.0"
+          "patch" "0.1.1"))
+      (testing "with prefix"
+        (are [scheme expected] (= expected (-> (assoc ctx :bump-version-scheme scheme
+                                                      :input/tag-prefix "v")
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "major" "v1.0.0"
+          "minor" "v0.2.0"
+          "patch" "v0.1.1")))
+
+    (testing "body"
+      (testing ":input/release-body"
+        (is (= "Version 0.2.0
+
+Hello World
+
+### Commits
+
+- [946550e6] Commit 10
+- [de6b1b7a] Commit 9
+- [2af2e1d6] Commit 8
+- [74ffa7bf] Commit 7
+"
+               (-> (assoc ctx :input/release-body "Hello World")
+                   (sut/generate-new-release-data related-data)
+                   (get :body)))))
+      (testing ":input/max-commits"
+        (are [max-commits ends-with] (= ends-with (-> (assoc ctx :input/max-commits max-commits)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :body)
+                                                      (str/split-lines)
+                                                      (last)))
+          1   "- [946550e6] Commit 10"
+          5   "- [74ffa7bf] Commit 7" ;commits are limited to range *after* 536a71ab
+          10  "- [74ffa7bf] Commit 7"
+          11  "- [74ffa7bf] Commit 7"
+          100 "- [74ffa7bf] Commit 7" ;larger number than what's available
+          )))))
+
+(deftest ^:integration generate-new-release-data-with-github-generated-release-notes
+  (let [[ctx related-data] @fixture-project-with-release
+        ctx                (assoc ctx :input/use-github-release-notes true)
+        release-data       (sut/generate-new-release-data ctx related-data)]
+
+    (testing "sets options to enable Github Generated Release Notes"
+      (is (= true (:generate_release_notes release-data)))
+      (is (= "Version 0.2.0\n\n" (:body release-data))))))

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -21,8 +21,8 @@
     "foo<<EOF\nhello\rworld\nEOF"  "hello\rworld"))
 
 (deftest prerelease-bump
-  (testing "prerelease bump"
-    (are [expected input] (= expected (sut/prerelease-bump input "pre"))
+  (testing "prerelease norelease bump"
+    (are [expected input] (= expected (sut/prerelease-bump input "pre" false))
         "0.0.0-pre" "0.0.0"
         "0.0.0-pre.1" "0.0.0-pre"
         "0.0.1-pre" "0.0.1"
@@ -31,7 +31,19 @@
         "0.1.0-pre.1" "0.1.0-pre"
         "1.1.0-pre" "1.1.0"
         "1.1.0-pre.1" "1.1.0-pre"
-        "1.1.0-pre.2" "1.1.0-pre.1")))
+        "1.1.0-pre.2" "1.1.0-pre.1"))
+
+  (testing "prerelease release bump"
+    (are [expected input] (= expected (sut/prerelease-bump input "pre" true))
+            "0.0.1-pre" "0.0.1"
+            "0.0.1-pre" "0.0.1-pre"
+            "0.0.1-pre" "0.0.1-pre.1"
+            "0.1.0-pre" "0.1.0"
+            "0.1.0-pre" "0.1.0-pre"
+            "0.1.0-pre" "0.1.0-pre.1"
+            "1.1.0-pre" "1.1.0"
+            "1.1.0-pre" "1.1.0-pre"
+            "1.1.0-pre" "1.1.0-pre.1")))
 
 (deftest semver-bump
   (testing "norelease bump"


### PR DESCRIPTION
# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level

I did not run integration tests locally as they did not work. Unsure how to get them to run. This could use some documentation but I wanted to get a feel for your thoughts on it. I suspect this hasn't been supported yet due there being no standard definition of prerelease versioning that can be followed. This PR takes an opinionated approach using `1.0.0` -> `1.0.0-pre` -> `1.0.0-pre.1` -> `1.0.0-pre.2` etc. It also bumps the main version separately so the PR labels can be combined to bump both at the same time.

Fixes #76.