### PR TITLE
feat: add automatic pre-release detection based on tag_suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ jobs:
 
 Yes, you can customize this by changing the `tag_prefix`. Here's an example of
 removing the prefix by using an empty string.
- 
+
 ``` yaml
 on:
   push:
@@ -195,6 +195,53 @@ jobs:
       - uses: rymndhng/release-on-push-action@master
         with:
           tag_prefix: ""
+```
+
+### Can I add a suffix to the Git Tags for pre-releases?
+
+Yes, you can add a suffix by using the `tag_suffix` parameter. This is useful for publishing alpha, beta, release candidate, or other pre-release versions.
+
+``` yaml
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: minor
+          tag_prefix: v
+          tag_suffix: -alpha
+```
+
+This will create tags like `v1.2.3-alpha`. Other common suffixes include:
+- `-beta` for beta releases
+- `-rc1`, `-rc2`, etc. for release candidates
+- `-preview` for preview releases
+
+**Releases with suffixes are automatically marked as pre-releases** in GitHub, following semantic versioning conventions.
+
+#### Controlling Pre-release Behavior
+
+The `use_prerelease` parameter controls whether releases are marked as pre-releases:
+- `auto` (default): Automatically marks as pre-release if `tag_suffix` is non-empty
+- `true`: Always marks as pre-release, even without a suffix
+- `false`: Never marks as pre-release, even with a suffix
+
+Example of forcing a production release with a suffix:
+
+``` yaml
+- uses: rymndhng/release-on-push-action@master
+  with:
+    tag_prefix: v
+    tag_suffix: -internal
+    use_prerelease: false  # Prevent marking as pre-release
 ```
 
 ### Can I change the name of the Release?

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: "Prefix to append to git tags. To unset this, set version_prefix to an empty string."
     required: false
     default: 'v'
+  tag_suffix:
+    description: "Suffix to append to git tags, e.g. '-alpha', '-rc1', '-beta'. Leave empty for no suffix."
+    required: false
+    default: ''
+  use_prerelease:
+    description: "Controls whether releases are marked as pre-releases. Set to 'auto' to auto-detect based on tag_suffix, 'true' to always mark as pre-release, 'false' to never mark as pre-release."
+    required: false
+    default: 'auto'
   release_name:
     description: |
       Name of the release. Supports these template variables:

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -39,6 +39,8 @@
    :input/max-commits   (Integer/parseInt (getenv-or-throw "INPUT_MAX_COMMITS"))
    :input/release-body  (System/getenv "INPUT_RELEASE_BODY")
    :input/tag-prefix    (System/getenv "INPUT_TAG_PREFIX") ;defaults to "v", see default in action.yml
+   :input/tag-suffix    (System/getenv "INPUT_TAG_SUFFIX") ;defaults to "", see default in action.yml
+   :input/use-prerelease (or (System/getenv "INPUT_USE_PRERELEASE") "auto")
    :input/release-name  (System/getenv "INPUT_RELEASE_NAME") ;defaults to "<RELEASE_TAG>", see default in action.yml
    :input/use-github-release-notes (Boolean/parseBoolean (System/getenv "INPUT_USE_GITHUB_RELEASE_NOTES"))
    :bump-version-scheme (assert-valid-bump-version-scheme
@@ -88,6 +90,23 @@
                        :patch [major minor (safe-inc patch)])]
     (str/join "." next-version)))
 
+(defn should-mark-prerelease?
+  "Determines if a release should be marked as a pre-release.
+
+  Rules:
+  - 'true' -> always true
+  - 'false' -> always false
+  - 'auto' -> true if tag-suffix is non-empty, false otherwise
+  "
+  [context]
+  (let [use-prerelease (:input/use-prerelease context)]
+    (case use-prerelease
+      "true"  true
+      "false" false
+      "auto"  (not (empty? (:input/tag-suffix context)))
+      ;; default: treat invalid values as auto
+      (not (empty? (:input/tag-suffix context))))))
+
 (defn norelease-reason [context related-data]
   (cond
     (= :norelease (bump-version-scheme context related-data))
@@ -104,7 +123,7 @@
         current-version     (get-tagged-version (:latest-release related-data))
         next-version        (semver-bump current-version bump-version-scheme)
         base-commit         (get-in related-data [:latest-release-commit :sha])
-        tag-name            (str (:input/tag-prefix context) next-version)
+        tag-name            (str (:input/tag-prefix context) next-version (:input/tag-suffix context))
 
         ;; this is a lazy sequence
         commits-since-last-release (->> (github/list-commits-to-base context base-commit)
@@ -129,7 +148,7 @@
                                  (str/replace "<RELEASE_TAG>" tag-name))
      :body                   body
      :draft                  false
-     :prerelease             false
+     :prerelease             (should-mark-prerelease? context)
      :generate_release_notes (:input/use-github-release-notes context)}))
 
 (defn create-new-release! [context new-release-data]

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -42,12 +42,31 @@
       "1.0.0" "0.1.0"
       "2.0.0" "1.1.0")))
 
+(deftest should-mark-prerelease?
+  (testing "explicit true"
+    (is (= true (sut/should-mark-prerelease?
+                 {:input/use-prerelease "true" :input/tag-suffix ""}))))
+
+  (testing "explicit false"
+    (is (= false (sut/should-mark-prerelease?
+                  {:input/use-prerelease "false" :input/tag-suffix "-alpha"}))))
+
+  (testing "auto mode with suffix"
+    (is (= true (sut/should-mark-prerelease?
+                 {:input/use-prerelease "auto" :input/tag-suffix "-alpha"}))))
+
+  (testing "auto mode without suffix"
+    (is (= false (sut/should-mark-prerelease?
+                  {:input/use-prerelease "auto" :input/tag-suffix ""})))))
+
 (def base-ctx
   {:token               (System/getenv "GITHUB_TOKEN") ;use Github Actions Token as test token
    :github/api-url      "https://api.github.com"
    :input/max-commits   5
    :input/release-body  ""
    :input/tag-prefix    ""
+   :input/tag-suffix    ""
+   :input/use-prerelease "auto"
    :input/use-github-release-notes false
    :input/release-name  "<RELEASE_TAG>"
    :bump-version-scheme "minor"
@@ -110,7 +129,45 @@
                                                (get :tag_name)))
           "major" "v1.0.0"
           "minor" "v0.1.0"
-          "patch" "v0.0.1")))
+          "patch" "v0.0.1"))
+      (testing "with suffix"
+        (are [suffix expected] (= expected (-> (assoc ctx :input/tag-suffix suffix)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "-alpha" "0.1.0-alpha"
+          "-rc1"   "0.1.0-rc1"
+          "-beta"  "0.1.0-beta"
+          ""       "0.1.0"))
+      (testing "with prefix and suffix"
+        (are [prefix suffix expected] (= expected (-> (assoc ctx
+                                                             :input/tag-prefix prefix
+                                                             :input/tag-suffix suffix)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :tag_name)))
+          "v" "-alpha" "v0.1.0-alpha"
+          "v" "-rc1"   "v0.1.0-rc1"
+          "v" ""       "v0.1.0"
+          ""  "-beta"  "0.1.0-beta")))
+
+    (testing "prerelease field"
+      (testing "auto-detect with suffix"
+        (is (= true (-> (assoc ctx :input/tag-suffix "-alpha")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "auto-detect without suffix"
+        (is (= false (-> ctx
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease)))))
+      (testing "explicit true overrides"
+        (is (= true (-> (assoc ctx :input/use-prerelease "true")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "explicit false overrides"
+        (is (= false (-> (assoc ctx
+                               :input/tag-suffix "-alpha"
+                               :input/use-prerelease "false")
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease))))))
 
     (testing "release_name"
       (are [template expected] (= expected (-> (assoc ctx
@@ -192,7 +249,43 @@ Hello World
                                                (get :tag_name)))
           "major" "v1.0.0"
           "minor" "v0.2.0"
-          "patch" "v0.1.1")))
+          "patch" "v0.1.1"))
+      (testing "with suffix"
+        (are [suffix expected] (= expected (-> (assoc ctx :input/tag-suffix suffix)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "-alpha" "0.2.0-alpha"
+          "-rc1"   "0.2.0-rc1"
+          ""       "0.2.0"))
+      (testing "with prefix and suffix"
+        (are [prefix suffix expected] (= expected (-> (assoc ctx
+                                                             :input/tag-prefix prefix
+                                                             :input/tag-suffix suffix)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :tag_name)))
+          "v" "-alpha" "v0.2.0-alpha"
+          "v" "-rc1"   "v0.2.0-rc1"
+          ""  "-beta"  "0.2.0-beta")))
+
+    (testing "prerelease field"
+      (testing "auto-detect with suffix"
+        (is (= true (-> (assoc ctx :input/tag-suffix "-alpha")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "auto-detect without suffix"
+        (is (= false (-> ctx
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease)))))
+      (testing "explicit true overrides"
+        (is (= true (-> (assoc ctx :input/use-prerelease "true")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "explicit false overrides"
+        (is (= false (-> (assoc ctx
+                               :input/tag-suffix "-alpha"
+                               :input/use-prerelease "false")
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease))))))
 
     (testing "body"
       (testing ":input/release-body"


### PR DESCRIPTION
  This action now supports:

    - adding tag_suffix parameter;
    - creating pre-release versions in GitHub.

  The tag_suffix parameter allows appending suffixes like -alpha, -rc1, or -beta to version tags.

  The new use_prerelease parameter controls whether releases are marked as pre-releases on GitHub.

  By default, these features work together: releases with a tag_suffix are automatically marked as pre-releases, following semantic versioning conventions where suffixed versions are considered pre-releases.

  The  input provides three modes:

    - 'auto' (default): marks as pre-release when tag_suffix is present
    - 'true': always marks as pre-release
    - 'false': never marks as pre-release

  This enables users to publish alpha, beta, and RC versions that are properly flagged in GitHub, while maintaining override capability for edge cases like internal releases with suffixes that should not be marked as pre-releases.

# PR Notes
- [ ] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level