### PR TITLE
feat: add automatic pre-release detection based on tag_suffix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,6 +30,8 @@ jobs:
           INPUT_BUMP_VERSION_SCHEME: minor
           INPUT_MAX_COMMITS: 5
           INPUT_TAG_PREFIX: v
+          INPUT_TAG_SUFFIX: -alpha
+          INPUT_USE_PRERELEASE: auto
           INPUT_RELEASE_NAME: <RELEASE_TAG>
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,11 +45,13 @@ jobs:
         run: docker build . -t rymndhng/release-on-push-action
 
       - name: Container Test
-        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e INPUT_RELEASE_NAME -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
+        run: docker run -e INPUT_BUMP_VERSION_SCHEME -e INPUT_MAX_COMMITS -e INPUT_TAG_PREFIX -e INPUT_TAG_SUFFIX -e INPUT_USE_PRERELEASE -e INPUT_RELEASE_NAME -e GITHUB_API_URL -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_TOKEN rymndhng/release-on-push-action --dry-run
         env:
           INPUT_BUMP_VERSION_SCHEME: minor
           INPUT_MAX_COMMITS: 5
           INPUT_TAG_PREFIX: v
+          INPUT_TAG_SUFFIX: -alpha
+          INPUT_USE_PRERELEASE: auto
           INPUT_RELEASE_NAME: <RELEASE_TAG>
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ jobs:
 
 Yes, you can customize this by changing the `tag_prefix`. Here's an example of
 removing the prefix by using an empty string.
- 
+
 ``` yaml
 on:
   push:
@@ -195,6 +195,53 @@ jobs:
       - uses: rymndhng/release-on-push-action@master
         with:
           tag_prefix: ""
+```
+
+### Can I add a suffix to the Git Tags for pre-releases?
+
+Yes, you can add a suffix by using the `tag_suffix` parameter. This is useful for publishing alpha, beta, release candidate, or other pre-release versions.
+
+``` yaml
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: minor
+          tag_prefix: v
+          tag_suffix: -alpha
+```
+
+This will create tags like `v1.2.3-alpha`. Other common suffixes include:
+- `-beta` for beta releases
+- `-rc1`, `-rc2`, etc. for release candidates
+- `-preview` for preview releases
+
+**Releases with suffixes are automatically marked as pre-releases** in GitHub, following semantic versioning conventions.
+
+#### Controlling Pre-release Behavior
+
+The `use_prerelease` parameter controls whether releases are marked as pre-releases:
+- `auto` (default): Automatically marks as pre-release if `tag_suffix` is non-empty
+- `true`: Always marks as pre-release, even without a suffix
+- `false`: Never marks as pre-release, even with a suffix
+
+Example of forcing a production release with a suffix:
+
+``` yaml
+- uses: rymndhng/release-on-push-action@master
+  with:
+    tag_prefix: v
+    tag_suffix: -internal
+    use_prerelease: false  # Prevent marking as pre-release
 ```
 
 ### Can I change the name of the Release?

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ This repository's pull requests are an example of this in action. For example, [
 
 Only one of these labels should be present on a PR. If there are multiple, the behavior is undefined.
 
+### How do I specify the tag suffix using Pull Request labels?
+
+You can override the `tag_suffix` parameter using a PR label in the format `tag-suffix:VALUE`, where VALUE is your desired suffix.
+
+**Examples:**
+- `tag-suffix:rc2` → sets suffix to `rc2`
+- `tag-suffix:-alpha` → sets suffix to `-alpha`
+- `tag-suffix:beta3` → sets suffix to `beta3`
+
+This is particularly useful for iterating pre-release versions without modifying workflow files:
+
+1. Create PR with labels: `release:keep` and `tag-suffix:rc2`
+2. Merge PR → automatically creates v2.0.0rc2 from v2.0.0rc1
+3. Next iteration: use `tag-suffix:rc3`
+
+**Priority:** Label-based suffix takes precedence over the workflow `tag_suffix` parameter.
+
 ### Do I need to setup Github Action access tokens or any other permission-related thing?
 
 Github Actions will inject a token for this plugin to interact with the API.
@@ -233,11 +250,13 @@ This will create tags like `v1.2.3-alpha`. Other common suffixes include:
 **Tip**: To iterate on pre-release versions (e.g., v2.0.0-rc1 → v2.0.0-rc2), use `bump_version_scheme: keep` or add the `release:keep` label to your PR. This keeps the base version unchanged and only changes the suffix.
 
 **Important**: When using `keep`, you must:
-1. Provide a `tag_suffix` parameter
+1. Provide a `tag_suffix` parameter (or `tag-suffix:VALUE` label)
 2. Have a previous release with a suffix (e.g., `-rc1`, `-alpha`)
 3. Use a different suffix than the previous release
 
-Example workflow for iterating release candidates:
+Example workflows for iterating release candidates:
+
+**Option 1: Using workflow configuration**
 ```yaml
 # First release: v2.0.0-rc1 (using minor/major/patch)
 # Next iteration: v2.0.0-rc2 (using keep)
@@ -246,13 +265,20 @@ Example workflow for iterating release candidates:
     bump_version_scheme: keep
     tag_prefix: v
     tag_suffix: -rc2  # or "rc2" without dash
+```
 
-# Alternative format without dash: v2.0.0rc1 -> v2.0.0rc2
+**Option 2: Using PR labels (recommended for iterative releases)**
+```yaml
+# Workflow stays the same, control via PR labels
 - uses: rymndhng/release-on-push-action@master
   with:
-    bump_version_scheme: keep
+    bump_version_scheme: minor  # overridden by PR label
     tag_prefix: v
-    tag_suffix: rc2  # no leading dash
+
+# PR labels:
+# - release:keep
+# - tag-suffix:rc2
+# Result: v2.0.0rc2 (if previous was v2.0.0rc1)
 ```
 
 #### Controlling Pre-release Behavior

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Allowed values of `bump_version_scheme`:
 - minor
 - major
 - patch
+- **keep**: Keeps the current version unchanged. Useful for iterating on pre-release suffixes (e.g., v2.0.0-rc1 → v2.0.0-rc2). Requirements: (1) Must provide a `tag_suffix`, (2) Previous version must have a suffix, (3) New suffix must differ from the previous one.
 - **norelease**: Performs no release by default. Creation of release delegated to labels on Pull Requests.
 
 For stability, we recommend pinning the version of the action. See [Releases](https://github.com/rymndhng/release-on-push-action/releases).
@@ -64,7 +65,7 @@ There are several approaches:
 
 ### How do I change the bump version scheme using Pull Requests?
 
-Iif the PR has the label `release:major`, `release:minor`, or `release:patch`, this will override `bump_version_scheme`. 
+If the PR has the label `release:major`, `release:minor`, `release:patch`, or `release:keep`, this will override `bump_version_scheme`.
 
 This repository's pull requests are an example of this in action. For example, [#19](https://github.com/rymndhng/release-on-push-action/pull/19).
 
@@ -221,11 +222,38 @@ jobs:
 ```
 
 This will create tags like `v1.2.3-alpha`. Other common suffixes include:
-- `-beta` for beta releases
-- `-rc1`, `-rc2`, etc. for release candidates
-- `-preview` for preview releases
+- `-beta` for beta releases (or `beta` without dash)
+- `-rc1`, `-rc2`, etc. for release candidates (or `rc1`, `rc2` without dash)
+- `-preview` for preview releases (or `preview` without dash)
+
+**Note**: Suffixes can be with or without a leading dash. Both `v2.0.0-rc1` and `v2.0.0rc1` are supported.
 
 **Releases with suffixes are automatically marked as pre-releases** in GitHub, following semantic versioning conventions.
+
+**Tip**: To iterate on pre-release versions (e.g., v2.0.0-rc1 → v2.0.0-rc2), use `bump_version_scheme: keep` or add the `release:keep` label to your PR. This keeps the base version unchanged and only changes the suffix.
+
+**Important**: When using `keep`, you must:
+1. Provide a `tag_suffix` parameter
+2. Have a previous release with a suffix (e.g., `-rc1`, `-alpha`)
+3. Use a different suffix than the previous release
+
+Example workflow for iterating release candidates:
+```yaml
+# First release: v2.0.0-rc1 (using minor/major/patch)
+# Next iteration: v2.0.0-rc2 (using keep)
+- uses: rymndhng/release-on-push-action@master
+  with:
+    bump_version_scheme: keep
+    tag_prefix: v
+    tag_suffix: -rc2  # or "rc2" without dash
+
+# Alternative format without dash: v2.0.0rc1 -> v2.0.0rc2
+- uses: rymndhng/release-on-push-action@master
+  with:
+    bump_version_scheme: keep
+    tag_prefix: v
+    tag_suffix: rc2  # no leading dash
+```
 
 #### Controlling Pre-release Behavior
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: 'Creates a Tag/Release on Push. Generates Release Notes. Customizab
 author: 'rymndhng'
 inputs:
   bump_version_scheme:
-    description: 'The bumping scheme to use by default. One of minor|major|patch|norelease'
+    description: 'The bumping scheme to use by default. One of minor|major|patch|keep|norelease'
     required: true
   release_body:
     description: "Additional text to insert into the release's body."
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: 'v'
   tag_suffix:
-    description: "Suffix to append to git tags, e.g. '-alpha', '-rc1', '-beta'. Leave empty for no suffix."
+    description: "Suffix to append to git tags, e.g. '-alpha', '-rc1', or 'alpha', 'rc1' (without dash). Leave empty for no suffix."
     required: false
     default: ''
   use_prerelease:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,14 @@ inputs:
     description: "Prefix to append to git tags. To unset this, set version_prefix to an empty string."
     required: false
     default: 'v'
+  tag_suffix:
+    description: "Suffix to append to git tags, e.g. '-alpha', '-rc1', '-beta'. Leave empty for no suffix."
+    required: false
+    default: ''
+  use_prerelease:
+    description: "Controls whether releases are marked as pre-releases. Set to 'auto' to auto-detect based on tag_suffix, 'true' to always mark as pre-release, 'false' to never mark as pre-release."
+    required: false
+    default: 'auto'
   release_name:
     description: |
       Name of the release. Supports these template variables:

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -66,6 +66,28 @@
 (defn get-labels [related-prs]
   (->> related-prs (map :labels) flatten (map :name) set))
 
+(defn extract-suffix-from-labels
+  "Extracts tag suffix from PR labels.
+
+  Looks for labels in format 'tag-suffix:VALUE' where VALUE is the suffix.
+  Examples: 'tag-suffix:rc2' -> 'rc2', 'tag-suffix:-alpha' -> '-alpha'
+
+  Returns nil if no tag-suffix label found."
+  [labels]
+  (some (fn [label]
+          (when (str/starts-with? label "tag-suffix:")
+            (subs label (count "tag-suffix:"))))
+        labels))
+
+(defn get-effective-tag-suffix
+  "Gets the effective tag suffix, prioritizing PR labels over context.
+
+  Priority: PR label > context input"
+  [context related-data]
+  (let [labels (get-labels (:related-prs related-data))
+        label-suffix (extract-suffix-from-labels labels)]
+    (or label-suffix (:input/tag-suffix context))))
+
 (defn bump-version-scheme [context related-data]
   (let [labels (get-labels (:related-prs related-data))]
     (cond
@@ -110,14 +132,15 @@
   - 'false' -> always false
   - 'auto' -> true if tag-suffix is non-empty, false otherwise
   "
-  [context]
-  (let [use-prerelease (:input/use-prerelease context)]
+  [context related-data]
+  (let [use-prerelease (:input/use-prerelease context)
+        effective-suffix (get-effective-tag-suffix context related-data)]
     (case use-prerelease
       "true"  true
       "false" false
-      "auto"  (boolean (seq (:input/tag-suffix context)))
+      "auto"  (boolean (seq effective-suffix))
       ;; default: treat invalid values as auto
-      (boolean (seq (:input/tag-suffix context))))))
+      (boolean (seq effective-suffix)))))
 
 (defn validate-keep-bump-scheme
   "Validates that 'keep' bump scheme is used correctly.
@@ -129,7 +152,7 @@
 
   Returns nil if valid, or an error message string if invalid."
   [context related-data]
-  (let [current-suffix (:input/tag-suffix context)
+  (let [current-suffix (get-effective-tag-suffix context related-data)
         previous-tag   (get-in related-data [:latest-release :tag_name])
         previous-suffix (when previous-tag (extract-suffix-from-tag previous-tag))]
     (cond
@@ -173,7 +196,8 @@
         current-version     (get-tagged-version (:latest-release related-data))
         next-version        (semver-bump current-version bump-version-scheme)
         base-commit         (get-in related-data [:latest-release-commit :sha])
-        tag-name            (str (:input/tag-prefix context) next-version (:input/tag-suffix context))
+        effective-suffix    (get-effective-tag-suffix context related-data)
+        tag-name            (str (:input/tag-prefix context) next-version effective-suffix)
 
         ;; this is a lazy sequence
         commits-since-last-release (->> (github/list-commits-to-base context base-commit)
@@ -198,7 +222,7 @@
                                  (str/replace "<RELEASE_TAG>" tag-name))
      :body                   body
      :draft                  false
-     :prerelease             (should-mark-prerelease? context)
+     :prerelease             (should-mark-prerelease? context related-data)
      :generate_release_notes (:input/use-github-release-notes context)}))
 
 (defn create-new-release! [context new-release-data]

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -103,9 +103,9 @@
     (case use-prerelease
       "true"  true
       "false" false
-      "auto"  (not (empty? (:input/tag-suffix context)))
+      "auto"  (boolean (seq (:input/tag-suffix context)))
       ;; default: treat invalid values as auto
-      (not (empty? (:input/tag-suffix context))))))
+      (boolean (seq (:input/tag-suffix context))))))
 
 (defn norelease-reason [context related-data]
   (cond

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -21,8 +21,8 @@
     false))
 
 (defn assert-valid-bump-version-scheme [bump-version-scheme]
-  (when-not (contains? #{"major" "minor" "patch" "norelease"} bump-version-scheme)
-    (throw (ex-info (str "Invalid bump-version-scheme. Expected one of major|minor|patch|norelease. Got: " bump-version-scheme) {:bump-version-scheme bump-version-scheme})))
+  (when-not (contains? #{"major" "minor" "patch" "keep" "norelease"} bump-version-scheme)
+    (throw (ex-info (str "Invalid bump-version-scheme. Expected one of major|minor|patch|keep|norelease. Got: " bump-version-scheme) {:bump-version-scheme bump-version-scheme})))
   bump-version-scheme)
 
 (defn context-from-env
@@ -72,6 +72,7 @@
       (contains? labels "release:major") :major
       (contains? labels "release:minor") :minor
       (contains? labels "release:patch") :patch
+      (contains? labels "release:keep")  :keep
       :else (keyword (:bump-version-scheme context)))))
 
 (defn get-tagged-version [latest-release]
@@ -79,15 +80,26 @@
         [prefix] (str/split tag #"\d+\.\d+\.\d+")] ;this strips any leading characters before the semver string
     (subs tag (count prefix))))
 
+(defn extract-suffix-from-tag
+  "Extracts the suffix from a tag name (e.g., 'v2.0.0-rc1' -> '-rc1', 'v2.0.0' -> '')"
+  [tag-name]
+  (if-let [match (re-find #"\d+\.\d+\.\d+(.*)" tag-name)]
+    (second match)
+    ""))
+
 (defn safe-inc [n]
   (inc (or n 0)))
 
 (defn semver-bump [version bump]
-  (let [[major minor patch] (map #(Integer/parseInt %) (str/split version #"\."))
+  (let [;; Extract just the semver portion (major.minor.patch) stripping any suffix
+        ;; Handles both "2.0.0-rc1" and "2.0.0rc1" formats
+        base-version (or (re-find #"^\d+\.\d+\.\d+" version) version)
+        [major minor patch] (map #(Integer/parseInt %) (str/split base-version #"\."))
         next-version (condp = bump
                        :major [(safe-inc major) 0 0]
                        :minor [major (safe-inc minor) 0]
-                       :patch [major minor (safe-inc patch)])]
+                       :patch [major minor (safe-inc patch)]
+                       :keep  [major minor patch])]
     (str/join "." next-version)))
 
 (defn should-mark-prerelease?
@@ -107,16 +119,54 @@
       ;; default: treat invalid values as auto
       (boolean (seq (:input/tag-suffix context))))))
 
+(defn validate-keep-bump-scheme
+  "Validates that 'keep' bump scheme is used correctly.
+
+  Requirements:
+  1. Current tag_suffix must be present (non-empty)
+  2. Previous version must have a suffix
+  3. New suffix must be different from previous suffix
+
+  Returns nil if valid, or an error message string if invalid."
+  [context related-data]
+  (let [current-suffix (:input/tag-suffix context)
+        previous-tag   (get-in related-data [:latest-release :tag_name])
+        previous-suffix (when previous-tag (extract-suffix-from-tag previous-tag))]
+    (cond
+      ;; No current suffix provided
+      (or (nil? current-suffix) (empty? current-suffix))
+      "Cannot use 'keep' bump scheme without a tag_suffix. Please provide a suffix (e.g., -rc2, -beta)."
+
+      ;; No previous release exists
+      (nil? previous-tag)
+      "Cannot use 'keep' bump scheme for the first release. Use 'minor', 'major', or 'patch' instead."
+
+      ;; Previous version has no suffix
+      (or (nil? previous-suffix) (empty? previous-suffix))
+      (format "Cannot use 'keep' bump scheme because previous version '%s' has no suffix. Use 'minor', 'major', or 'patch' to bump the version first." previous-tag)
+
+      ;; Current suffix same as previous suffix
+      (= current-suffix previous-suffix)
+      (format "Cannot use 'keep' bump scheme with the same suffix. Previous version '%s' already uses suffix '%s'. Please provide a different suffix." previous-tag previous-suffix)
+
+      ;; All validations passed
+      :else nil)))
+
 (defn norelease-reason [context related-data]
-  (cond
-    (= :norelease (bump-version-scheme context related-data))
-    "Skipping release, no version bump found."
+  (let [scheme (bump-version-scheme context related-data)]
+    (cond
+      (= :norelease scheme)
+      "Skipping release, no version bump found."
 
-    (str/includes? (github/commit-title (:commit related-data)) "[norelease]")
-    "Skipping release. Reason: git commit title contains [norelease]"
+      (str/includes? (github/commit-title (:commit related-data)) "[norelease]")
+      "Skipping release. Reason: git commit title contains [norelease]"
 
-    (contains? (get-labels (get-in related-data [:related-prs])) "norelease")
-    "Skipping release. Reason: related PR has label norelease"))
+      (contains? (get-labels (get-in related-data [:related-prs])) "norelease")
+      "Skipping release. Reason: related PR has label norelease"
+
+      ;; Validate 'keep' bump scheme
+      (= :keep scheme)
+      (validate-keep-bump-scheme context related-data))))
 
 (defn generate-new-release-data [context related-data]
   (let [bump-version-scheme (bump-version-scheme context related-data)

--- a/src/release_on_push_action/core.clj
+++ b/src/release_on_push_action/core.clj
@@ -39,6 +39,8 @@
    :input/max-commits   (Integer/parseInt (getenv-or-throw "INPUT_MAX_COMMITS"))
    :input/release-body  (System/getenv "INPUT_RELEASE_BODY")
    :input/tag-prefix    (System/getenv "INPUT_TAG_PREFIX") ;defaults to "v", see default in action.yml
+   :input/tag-suffix    (System/getenv "INPUT_TAG_SUFFIX") ;defaults to "", see default in action.yml
+   :input/use-prerelease (or (System/getenv "INPUT_USE_PRERELEASE") "auto")
    :input/release-name  (System/getenv "INPUT_RELEASE_NAME") ;defaults to "<RELEASE_TAG>", see default in action.yml
    :input/use-github-release-notes (Boolean/parseBoolean (System/getenv "INPUT_USE_GITHUB_RELEASE_NOTES"))
    :bump-version-scheme (assert-valid-bump-version-scheme
@@ -88,6 +90,23 @@
                        :patch [major minor (safe-inc patch)])]
     (str/join "." next-version)))
 
+(defn should-mark-prerelease?
+  "Determines if a release should be marked as a pre-release.
+
+  Rules:
+  - 'true' -> always true
+  - 'false' -> always false
+  - 'auto' -> true if tag-suffix is non-empty, false otherwise
+  "
+  [context]
+  (let [use-prerelease (:input/use-prerelease context)]
+    (case use-prerelease
+      "true"  true
+      "false" false
+      "auto"  (not (empty? (:input/tag-suffix context)))
+      ;; default: treat invalid values as auto
+      (not (empty? (:input/tag-suffix context))))))
+
 (defn norelease-reason [context related-data]
   (cond
     (= :norelease (bump-version-scheme context related-data))
@@ -104,7 +123,7 @@
         current-version     (get-tagged-version (:latest-release related-data))
         next-version        (semver-bump current-version bump-version-scheme)
         base-commit         (get-in related-data [:latest-release-commit :sha])
-        tag-name            (str (:input/tag-prefix context) next-version)
+        tag-name            (str (:input/tag-prefix context) next-version (:input/tag-suffix context))
 
         ;; this is a lazy sequence
         commits-since-last-release (->> (github/list-commits-to-base context base-commit)
@@ -129,7 +148,7 @@
                                  (str/replace "<RELEASE_TAG>" tag-name))
      :body                   body
      :draft                  false
-     :prerelease             false
+     :prerelease             (should-mark-prerelease? context)
      :generate_release_notes (:input/use-github-release-notes context)}))
 
 (defn create-new-release! [context new-release-data]

--- a/src/release_on_push_action/github.clj
+++ b/src/release_on_push_action/github.clj
@@ -54,20 +54,31 @@
 
 ;; -- Github Releases API  -----------------------------------------------------
 (defn fetch-latest-release
-  "Gets the latest commit. Returns nil when there is no release.
+  "Gets the latest release including pre-releases. Returns nil when there is no release.
 
-  See https://developer.github.com/v3/repos/releases/#get-the-latest-release"
+  Note: Uses /releases endpoint instead of /releases/latest to include pre-releases.
+  The API returns releases sorted by created_at descending, so first item is most recent.
+
+  See https://docs.github.com/en/rest/releases/releases#list-releases"
   [context]
   (try
-    (parse-response
-     (curl/get
-      (format "%s/repos/%s/releases/latest" (:github/api-url context) (:repo context))
-      {:headers (headers context)}))
+    (let [response (parse-response
+                    (curl/get
+                     (format "%s/repos/%s/releases?per_page=1" (:github/api-url context) (:repo context))
+                     {:headers (headers context)}))
+          releases (:body response)]
+      (if (and releases (seq releases))
+        (assoc response :body (first releases))
+        (do
+          (println "No release found for project.")
+          nil)))
     (catch clojure.lang.ExceptionInfo ex
       (cond
         ;; No previous release created, return nil
         (= 404 (:status (ex-data ex)))
-        (println "No release found for project.")
+        (do
+          (println "No release found for project.")
+          nil)
 
         :else (throw ex)))))
 

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -42,12 +42,31 @@
       "1.0.0" "0.1.0"
       "2.0.0" "1.1.0")))
 
+(deftest should-mark-prerelease?
+  (testing "explicit true"
+    (is (= true (sut/should-mark-prerelease?
+                 {:input/use-prerelease "true" :input/tag-suffix ""}))))
+
+  (testing "explicit false"
+    (is (= false (sut/should-mark-prerelease?
+                  {:input/use-prerelease "false" :input/tag-suffix "-alpha"}))))
+
+  (testing "auto mode with suffix"
+    (is (= true (sut/should-mark-prerelease?
+                 {:input/use-prerelease "auto" :input/tag-suffix "-alpha"}))))
+
+  (testing "auto mode without suffix"
+    (is (= false (sut/should-mark-prerelease?
+                  {:input/use-prerelease "auto" :input/tag-suffix ""})))))
+
 (def base-ctx
   {:token               (System/getenv "GITHUB_TOKEN") ;use Github Actions Token as test token
    :github/api-url      "https://api.github.com"
    :input/max-commits   5
    :input/release-body  ""
    :input/tag-prefix    ""
+   :input/tag-suffix    ""
+   :input/use-prerelease "auto"
    :input/use-github-release-notes false
    :input/release-name  "<RELEASE_TAG>"
    :bump-version-scheme "minor"
@@ -110,7 +129,45 @@
                                                (get :tag_name)))
           "major" "v1.0.0"
           "minor" "v0.1.0"
-          "patch" "v0.0.1")))
+          "patch" "v0.0.1"))
+      (testing "with suffix"
+        (are [suffix expected] (= expected (-> (assoc ctx :input/tag-suffix suffix)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "-alpha" "0.1.0-alpha"
+          "-rc1"   "0.1.0-rc1"
+          "-beta"  "0.1.0-beta"
+          ""       "0.1.0"))
+      (testing "with prefix and suffix"
+        (are [prefix suffix expected] (= expected (-> (assoc ctx
+                                                             :input/tag-prefix prefix
+                                                             :input/tag-suffix suffix)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :tag_name)))
+          "v" "-alpha" "v0.1.0-alpha"
+          "v" "-rc1"   "v0.1.0-rc1"
+          "v" ""       "v0.1.0"
+          ""  "-beta"  "0.1.0-beta")))
+
+    (testing "prerelease field"
+      (testing "auto-detect with suffix"
+        (is (= true (-> (assoc ctx :input/tag-suffix "-alpha")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "auto-detect without suffix"
+        (is (= false (-> ctx
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease)))))
+      (testing "explicit true overrides"
+        (is (= true (-> (assoc ctx :input/use-prerelease "true")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "explicit false overrides"
+        (is (= false (-> (assoc ctx
+                               :input/tag-suffix "-alpha"
+                               :input/use-prerelease "false")
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease))))))
 
     (testing "release_name"
       (are [template expected] (= expected (-> (assoc ctx
@@ -192,7 +249,43 @@ Hello World
                                                (get :tag_name)))
           "major" "v1.0.0"
           "minor" "v0.2.0"
-          "patch" "v0.1.1")))
+          "patch" "v0.1.1"))
+      (testing "with suffix"
+        (are [suffix expected] (= expected (-> (assoc ctx :input/tag-suffix suffix)
+                                               (sut/generate-new-release-data related-data)
+                                               (get :tag_name)))
+          "-alpha" "0.2.0-alpha"
+          "-rc1"   "0.2.0-rc1"
+          ""       "0.2.0"))
+      (testing "with prefix and suffix"
+        (are [prefix suffix expected] (= expected (-> (assoc ctx
+                                                             :input/tag-prefix prefix
+                                                             :input/tag-suffix suffix)
+                                                      (sut/generate-new-release-data related-data)
+                                                      (get :tag_name)))
+          "v" "-alpha" "v0.2.0-alpha"
+          "v" "-rc1"   "v0.2.0-rc1"
+          ""  "-beta"  "0.2.0-beta")))
+
+    (testing "prerelease field"
+      (testing "auto-detect with suffix"
+        (is (= true (-> (assoc ctx :input/tag-suffix "-alpha")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "auto-detect without suffix"
+        (is (= false (-> ctx
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease)))))
+      (testing "explicit true overrides"
+        (is (= true (-> (assoc ctx :input/use-prerelease "true")
+                        (sut/generate-new-release-data related-data)
+                        (get :prerelease)))))
+      (testing "explicit false overrides"
+        (is (= false (-> (assoc ctx
+                               :input/tag-suffix "-alpha"
+                               :input/use-prerelease "false")
+                         (sut/generate-new-release-data related-data)
+                         (get :prerelease))))))
 
     (testing "body"
       (testing ":input/release-body"

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -40,7 +40,76 @@
       "1.0.0" "0.0.0"
       "1.0.0" "0.0.1"
       "1.0.0" "0.1.0"
-      "2.0.0" "1.1.0")))
+      "2.0.0" "1.1.0"))
+
+  (testing "keep version"
+    (are [expected input] (= expected (sut/semver-bump input :keep))
+      "0.0.0" "0.0.0"
+      "1.2.3" "1.2.3"
+      "2.0.0" "2.0.0"))
+
+  (testing "bump with suffixed versions"
+    (testing "strips suffix before bumping (with dash)"
+      (are [expected input bump] (= expected (sut/semver-bump input bump))
+        "2.0.0" "2.0.0-rc1"   :keep
+        "3.0.0" "2.0.0-alpha" :major
+        "2.1.0" "2.0.0-beta"  :minor
+        "2.0.1" "2.0.0-rc2"   :patch))
+    (testing "strips suffix before bumping (without dash)"
+      (are [expected input bump] (= expected (sut/semver-bump input bump))
+        "2.0.0" "2.0.0rc1"    :keep
+        "3.0.0" "2.0.0alpha"  :major
+        "2.1.0" "2.0.0beta"   :minor
+        "2.0.1" "2.0.0rc2"    :patch))))
+
+(deftest extract-suffix-from-tag
+  (testing "extract suffix from various tag formats"
+    (are [expected tag] (= expected (sut/extract-suffix-from-tag tag))
+      "-rc1"   "v2.0.0-rc1"
+      "-alpha" "v1.0.0-alpha"
+      "-beta"  "2.0.0-beta"
+      ""       "v2.0.0"
+      ""       "1.0.0"
+      "-rc2"   "prefix2.0.0-rc2"
+      "rc1"    "v2.0.0rc1"    ; without dash
+      "alpha"  "1.0.0alpha"   ; without dash
+      "beta2"  "2.0.0beta2")))
+
+(deftest validate-keep-bump-scheme
+  (testing "missing current suffix"
+    (is (string? (sut/validate-keep-bump-scheme
+                  {:input/tag-suffix ""}
+                  {:latest-release {:tag_name "v1.0.0-rc1"}}))))
+
+  (testing "no previous release"
+    (is (string? (sut/validate-keep-bump-scheme
+                  {:input/tag-suffix "-rc2"}
+                  {:latest-release nil}))))
+
+  (testing "previous version has no suffix"
+    (is (string? (sut/validate-keep-bump-scheme
+                  {:input/tag-suffix "-rc1"}
+                  {:latest-release {:tag_name "v1.0.0"}}))))
+
+  (testing "same suffix as previous (with dash)"
+    (is (string? (sut/validate-keep-bump-scheme
+                  {:input/tag-suffix "-rc1"}
+                  {:latest-release {:tag_name "v1.0.0-rc1"}}))))
+
+  (testing "valid: different suffix (with dash)"
+    (is (nil? (sut/validate-keep-bump-scheme
+               {:input/tag-suffix "-rc2"}
+               {:latest-release {:tag_name "v1.0.0-rc1"}}))))
+
+  (testing "same suffix as previous (without dash)"
+    (is (string? (sut/validate-keep-bump-scheme
+                  {:input/tag-suffix "rc1"}
+                  {:latest-release {:tag_name "v1.0.0rc1"}}))))
+
+  (testing "valid: different suffix (without dash)"
+    (is (nil? (sut/validate-keep-bump-scheme
+               {:input/tag-suffix "rc2"}
+               {:latest-release {:tag_name "v1.0.0rc1"}})))))
 
 (deftest should-mark-prerelease?
   (testing "explicit true"

--- a/test/release_on_push_action/core_test.clj
+++ b/test/release_on_push_action/core_test.clj
@@ -111,22 +111,60 @@
                {:input/tag-suffix "rc2"}
                {:latest-release {:tag_name "v1.0.0rc1"}})))))
 
+(deftest extract-suffix-from-labels
+  (testing "extracts suffix from tag-suffix: label"
+    (are [expected labels] (= expected (sut/extract-suffix-from-labels labels))
+      "rc2"    #{"release:minor" "tag-suffix:rc2"}
+      "-alpha" #{"tag-suffix:-alpha" "bug"}
+      "beta"   #{"tag-suffix:beta"}
+      nil      #{"release:major" "bug"}
+      nil      #{})))
+
+(deftest get-effective-tag-suffix
+  (testing "prioritizes label over context"
+    (is (= "rc2"
+           (sut/get-effective-tag-suffix
+            {:input/tag-suffix "-rc1"}
+            {:related-prs [{:labels [{:name "tag-suffix:rc2"}]}]}))))
+
+  (testing "falls back to context when no label"
+    (is (= "-rc1"
+           (sut/get-effective-tag-suffix
+            {:input/tag-suffix "-rc1"}
+            {:related-prs []}))))
+
+  (testing "returns nil when neither label nor context"
+    (is (= nil
+           (sut/get-effective-tag-suffix
+            {:input/tag-suffix nil}
+            {:related-prs []})))))
+
 (deftest should-mark-prerelease?
-  (testing "explicit true"
-    (is (= true (sut/should-mark-prerelease?
-                 {:input/use-prerelease "true" :input/tag-suffix ""}))))
+  (let [empty-related-data {:related-prs []}]
+    (testing "explicit true"
+      (is (= true (sut/should-mark-prerelease?
+                   {:input/use-prerelease "true" :input/tag-suffix ""}
+                   empty-related-data))))
 
-  (testing "explicit false"
-    (is (= false (sut/should-mark-prerelease?
-                  {:input/use-prerelease "false" :input/tag-suffix "-alpha"}))))
+    (testing "explicit false"
+      (is (= false (sut/should-mark-prerelease?
+                    {:input/use-prerelease "false" :input/tag-suffix "-alpha"}
+                    empty-related-data))))
 
-  (testing "auto mode with suffix"
-    (is (= true (sut/should-mark-prerelease?
-                 {:input/use-prerelease "auto" :input/tag-suffix "-alpha"}))))
+    (testing "auto mode with suffix"
+      (is (= true (sut/should-mark-prerelease?
+                   {:input/use-prerelease "auto" :input/tag-suffix "-alpha"}
+                   empty-related-data))))
 
-  (testing "auto mode without suffix"
-    (is (= false (sut/should-mark-prerelease?
-                  {:input/use-prerelease "auto" :input/tag-suffix ""})))))
+    (testing "auto mode without suffix"
+      (is (= false (sut/should-mark-prerelease?
+                    {:input/use-prerelease "auto" :input/tag-suffix ""}
+                    empty-related-data))))
+
+    (testing "auto mode with label-based suffix"
+      (is (= true (sut/should-mark-prerelease?
+                   {:input/use-prerelease "auto" :input/tag-suffix ""}
+                   {:related-prs [{:labels [{:name "tag-suffix:rc2"}]}]}))))))
 
 (def base-ctx
   {:token               (System/getenv "GITHUB_TOKEN") ;use Github Actions Token as test token


### PR DESCRIPTION
  This action now supports:

    - adding tag_suffix parameter;
    - creating pre-release versions in GitHub.

  The tag_suffix parameter allows appending suffixes like -alpha, -rc1, or -beta to version tags.

  The new use_prerelease parameter controls whether releases are marked as pre-releases on GitHub.

  By default, these features work together: releases with a tag_suffix are automatically marked as pre-releases, following semantic versioning conventions where suffixed versions are considered pre-releases.

  The  input provides three modes:

    - 'auto' (default): marks as pre-release when tag_suffix is present
    - 'true': always marks as pre-release
    - 'false': never marks as pre-release

  This enables users to publish alpha, beta, and RC versions that are properly flagged in GitHub, while maintaining override capability for edge cases like internal releases with suffixes that should not be marked as pre-releases.

Later change:

- Implements 'keep' bump scheme that maintains version number while changing suffix (e.g., vX.Y.Z-rc1 → vX.Y.Z-rc2), with validation requiring non-empty suffix, previous version with suffix, and different suffix from previous.

- Updates fetch-latest-release to use /releases endpoint instead of /releases/latest to include pre-releases, and adds support for both dash-separated (vX.Y.Z-rc1) and non-dash (vX.Y.Zrc1) suffix formats.

- Added support for label-based suffix. Label format: tag-suffix:VALUE.

# PR Notes
- [x] Reviewed Checks: Verified output of Integration Tests
- [ ] Have set labels for release level